### PR TITLE
Fix cocoBoot acceptance-envelope quantiles (0.1.2)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Coconots"
 uuid = "2061d889-07fc-48e0-ab41-7cc4d945d6d4"
 authors = ["Manuel Huth", "Robert C. Jung", "Andy Tremayne"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/CocoBoot.jl
+++ b/src/CocoBoot.jl
@@ -34,8 +34,8 @@ and then compares these intervals with the PACF computed from the observed data.
 
 # Returns
 A dictionary with the following keys:
-- `"upper"`: The lower quantile values (first column) of the bootstrapped PACF for each lag.
-- `"lower"`: The upper quantile values (second column) of the bootstrapped PACF for each lag.
+- `"lower"`: The lower quantile values (first column) of the bootstrapped PACF for each lag.
+- `"upper"`: The upper quantile values (second column) of the bootstrapped PACF for each lag.
 - `"in_interval"`: A Boolean vector indicating if the observed PACF values lie within the bootstrap confidence intervals.
 - `"pacf_data"`: The PACF computed from the observed data.
 - `"pacfs"`: The matrix of bootstrapped PACF values.
@@ -44,11 +44,11 @@ A dictionary with the following keys:
 function cocoBoot(cocoReg_fit, lags=[1:1:21;], n_bootstrap=400, alpha=0.05, n_burn_in=200, store_matrix = Array{Float64}(undef, length(lags), 2))
     pacfs = compute_random_pacfs(cocoReg_fit, lags, Int(n_bootstrap), n_burn_in, Array{Float64}(undef, Int(n_bootstrap), length(lags)))
     for i in 1:length(lags)
-        store_matrix[i, :] = quantile!(pacfs[:, i], [alpha/2, (1 - alpha)/2])
+        store_matrix[i, :] = quantile!(pacfs[:, i], [alpha/2, 1 - alpha/2])
     end
     pacf_data = compute_partial_autocorrelation(Int.(cocoReg_fit["data"]), lags)
-    return Dict("upper" => store_matrix[:, 1],
-                "lower" => store_matrix[:, 2],
+    return Dict("lower" => store_matrix[:, 1],
+                "upper" => store_matrix[:, 2],
                 "in_interval" => (store_matrix[:, 1] .< pacf_data) .& (store_matrix[:, 2] .> pacf_data),
                 "pacf_data" => pacf_data,
                 "pacfs" => pacfs,


### PR DESCRIPTION
## Summary

`cocoBoot` computed the upper bootstrap acceptance-envelope quantile as
`(1 - alpha)/2` — i.e. `0.475` for `alpha = 0.05` — instead of `1 - alpha/2`
(`0.975`). This produced an asymmetric envelope that was far too narrow on the
upper side. This PR:

- Fixes the quantile to `[alpha/2, 1 - alpha/2]`.
- Fixes the swapped `"lower"` / `"upper"` keys in the returned `Dict` (and the
  docstring). `store_matrix[:, 1]` is the lower (`alpha/2`) quantile and
  `store_matrix[:, 2]` is the upper (`1 - alpha/2`) quantile. The `in_interval`
  membership test was already correct.
- Bumps the package version to `0.1.2`.

## Verification

Fit → `cocoBoot` round-trip on a simulated series: the returned `lower`/`upper`
now equal the independently computed `[0.025, 0.975]` quantiles of the raw
bootstrap replicate matrix, and `lower < upper` at every lag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
