### PR TITLE
Rework backend for speed and modularity; migrate to Optimization.jl (v0.2.0)

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,1 @@
+style = "sciml"

--- a/Project.toml
+++ b/Project.toml
@@ -1,35 +1,33 @@
 name = "Coconots"
 uuid = "2061d889-07fc-48e0-ab41-7cc4d945d6d4"
+version = "0.2.0"
 authors = ["Manuel Huth", "Robert C. Jung", "Andy Tremayne"]
-version = "0.1.2"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 FreqTables = "da1fdf0e-e0ff-5433-a45f-9bb5ff651cb1"
-LineSearches = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
+Optimization = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
+OptimizationOptimJL = "36348300-93cb-4f02-beb5-3c3902f8871e"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 DataFrames = "1.7.0"
-Distributions = "0.25.118"
-ForwardDiff = "0.10.38"
+ForwardDiff = "0.10, 1"
 FreqTables = "0.4.6"
-LineSearches = "7.3.0"
-LinearAlgebra = "1.11.0"
+LinearAlgebra = "1.10, 1.11, 1.12"
 Optim = "1.11.0"
-PrecompileTools = "1.2.1"
-Random = "1.11.0"
+Optimization = "5"
+OptimizationOptimJL = "0.4"
+PrecompileTools = "1.2"
+Random = "1.10, 1.11, 1.12"
+SpecialFunctions = "2"
+Statistics = "1.10, 1.11, 1.12"
 StatsBase = "0.34.4"
-julia = "1.6.7"
-
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test"]
+julia = "1.10"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ fit = cocoReg(type, order, data; box_constrained = true)  # Fminbox(LBFGS())
 # fit = cocoReg(type, order, data; adtype = AutoEnzyme())
 ```
 
+The likelihood evaluations are multithreaded, but a Julia process starts
+single-threaded by default: launch with `julia --threads=8` (or set
+`JULIA_NUM_THREADS`) to activate the parallel paths. Second-order fits on
+long or overdispersed series gain roughly 3x on 8 threads; when calling from
+R via JuliaConnectoR, set `Sys.setenv(JULIA_NUM_THREADS = "8")` before the
+first Julia call of the session.
+
 ### Model Diagnostics
 
 Perform residual diagnostics and bootstrap:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ The `Coconots` package provides a robust and user-friendly Julia framework for a
 - First- and higher-order integer autoregressive models
 - Supports Poisson and generalized Poisson distributions
 - Inclusion of covariates with customizable link functions
-- Efficient likelihood-based inference and forecasting
+- Efficient likelihood-based inference and forecasting: type-stable,
+  allocation-light convolution kernels with precomputed lookup tables
+- Optimization via the [Optimization.jl](https://github.com/SciML/Optimization.jl)
+  interface with pluggable solvers and automatic-differentiation backends
+  (ForwardDiff by default; Enzyme, ReverseDiff, etc. via `adtype`)
 - Comprehensive tools for model validation and diagnostics
 
 ## Installation
@@ -61,6 +65,24 @@ Fit a second-order model to simulated data:
 
 ```julia
 fit2 = cocoReg(type, order2, data2)
+```
+
+Parameter constraints are handled by smooth parameter transformations by
+default, so the problem is solved unconstrained (with `LBFGS()`). The
+optimizer and the automatic-differentiation backend are pluggable: any
+Optimization.jl solver and any `ADTypes` backend can be used; extra keyword
+arguments are forwarded to `Optimization.solve`:
+
+```julia
+fit = cocoReg(type, order, data; adtype = Optimization.AutoForwardDiff(),
+    maxiters = 500)
+
+# solver-enforced box constraints instead of transformations:
+fit = cocoReg(type, order, data; box_constrained = true)  # Fminbox(LBFGS())
+
+# with Enzyme loaded, reverse-mode AD:
+# import Enzyme
+# fit = cocoReg(type, order, data; adtype = AutoEnzyme())
 ```
 
 ### Model Diagnostics

--- a/src/Bounds.jl
+++ b/src/Bounds.jl
@@ -1,99 +1,42 @@
-"""
-    get_bounds_GP2(type, covariates, lower_bound_covariates)
-
-Computes the lower and upper bounds for the parameter vector for second-order models.
-For "GP" (generalized Poisson) models, the parameter vector is assumed to consist of three autoregressive parameters,
-one dispersion parameter, and additional covariate parameters. For "Poisson" models, the dispersion parameter is omitted.
-The covariate bounds are set to `lower_bound_covariates` for the lower bound and `Inf` for the upper bound.
-
-# Arguments
-- `type`: A string specifying the model type ("GP" or "Poisson").
-- `covariates`: A matrix of covariate values, or `nothing` if there are no covariates.
-- `lower_bound_covariates`: A numeric lower bound for each covariate parameter.
-
-# Returns
-A tuple `(lower, upper)` where:
-- `lower` is a vector of lower bounds.
-- `upper` is a vector of upper bounds.
-For "GP" models, the bounds are constructed as `vcat([0, 0, 0], [0], lambda_lower)`,
-and for "Poisson" models as `vcat([0, 0, 0], lambda_lower)`.
-"""
-function get_bounds_GP2(type, covariates, lower_bound_covariates)
-    lambda_lower = [0]
-    lambda_upper = [Inf]
-    if !isnothing(covariates)
-        lambda_lower = repeat([lower_bound_covariates], size(covariates, 2))
-        lambda_upper = repeat([Inf], size(covariates, 2))
-    end
-
-    if type == "GP"
-        lower = vcat([0, 0, 0], [0], lambda_lower)
-        upper = vcat([1, 1, 1], [1], lambda_upper)
-    elseif type == "Poisson"
-        lower = vcat([0, 0, 0], lambda_lower)
-        upper = vcat([1, 1, 1], lambda_upper)
-    end
-    return lower, upper
+function _covariate_bounds(covariates, lower_bound_covariates)
+    covariates === nothing && return [0.0], [Inf]
+    n_betas = size(covariates, 2)
+    return fill(Float64(lower_bound_covariates), n_betas), fill(Inf, n_betas)
 end
 
 """
     get_bounds_GP1(type, covariates, lower_bound_covariates)
 
-Computes the lower and upper bounds for the parameter vector for first-order models.
-For "GP" (generalized Poisson) models, the parameter vector is assumed to consist of one autoregressive parameter,
-one dispersion parameter, and additional covariate parameters. For "Poisson" models, the dispersion parameter is omitted.
-The covariate bounds are set to `lower_bound_covariates` for the lower bound and `Inf` for the upper bound.
-
-# Arguments
-- `type`: A string specifying the model type ("GP" or "Poisson").
-- `covariates`: A matrix of covariate values, or `nothing` if there are no covariates.
-- `lower_bound_covariates`: A numeric lower bound for each covariate parameter.
-
-# Returns
-A tuple `(lower, upper)` where:
-- `lower` is a vector of lower bounds.
-- `upper` is a vector of upper bounds.
-For "GP" models, the bounds are constructed as `vcat([0], [0], lambda_lower)`,
-and for "Poisson" models as `vcat([0], lambda_lower)`.
+Box constraints `(lower, upper)` of the first-order parameter vector:
+`alpha[, eta], lambda` (or the covariate coefficients in place of `lambda`).
 """
 function get_bounds_GP1(type, covariates, lower_bound_covariates)
-    lambda_lower = [0]
-    lambda_upper = [Inf]
-    if !isnothing(covariates)
-        lambda_lower = repeat([lower_bound_covariates], size(covariates, 2))
-        lambda_upper = repeat([Inf], size(covariates, 2))
-    end
+    lambda_lower, lambda_upper = _covariate_bounds(covariates, lower_bound_covariates)
+    n_base = type == "GP" ? 2 : 1
+    return vcat(zeros(n_base), lambda_lower), vcat(ones(n_base), lambda_upper)
+end
 
-    if type == "GP"
-        lower = vcat([0], [0], lambda_lower)
-        upper = vcat([1], [1], lambda_upper)
-    elseif type == "Poisson"
-        lower = vcat([0], lambda_lower)
-        upper = vcat([1], lambda_upper)
-    end
-    return lower, upper
+"""
+    get_bounds_GP2(type, covariates, lower_bound_covariates)
+
+Box constraints `(lower, upper)` of the second-order parameter vector:
+`alpha1, alpha2, alpha3[, eta], lambda` (or the covariate coefficients in
+place of `lambda`).
+"""
+function get_bounds_GP2(type, covariates, lower_bound_covariates)
+    lambda_lower, lambda_upper = _covariate_bounds(covariates, lower_bound_covariates)
+    n_base = type == "GP" ? 4 : 3
+    return vcat(zeros(n_base), lambda_lower), vcat(ones(n_base), lambda_upper)
 end
 
 """
     get_bounds(order, type, covariates, lower_bound_covariates)
 
-Selects and returns the lower and upper bounds for the parameter vector based on the model order.
-For first-order models, it calls `get_bounds_GP1`; for second-order models, it calls `get_bounds_GP2`.
-
-# Arguments
-- `order`: An integer indicating the autoregressive order (1 or 2).
-- `type`: A string specifying the model type ("GP" or "Poisson").
-- `covariates`: A matrix of covariate values, or `nothing` if none.
-- `lower_bound_covariates`: A numeric lower bound for the covariate parameters.
-
-# Returns
-A tuple `(lower, upper)` where `lower` is a vector of lower bounds and `upper` is a vector of upper bounds appropriate
-for the specified model order and type.
+Box constraints for the parameter vector of the given model order and type.
 """
 function get_bounds(order, type, covariates, lower_bound_covariates)
-    if order == 1
+    if Int(order) == 1
         return get_bounds_GP1(type, covariates, lower_bound_covariates)
-    elseif order == 2
-        return get_bounds_GP2(type, covariates, lower_bound_covariates)
     end
+    return get_bounds_GP2(type, covariates, lower_bound_covariates)
 end

--- a/src/CocoBoot.jl
+++ b/src/CocoBoot.jl
@@ -3,79 +3,48 @@ export compute_partial_autocorrelation, cocoBoot, compute_random_pacfs
 """
     compute_partial_autocorrelation(x, lags)
 
-Computes the (partial) autocorrelation of the input vector `x` at the specified `lags`.
-This function calls `autocor` with demeaning enabled.
-
-# Arguments
-- `x`: A vector of numerical observations.
-- `lags`: A scalar or vector indicating the lag(s) at which to compute the autocorrelation.
-
-# Returns
-A vector of autocorrelation coefficients corresponding to the specified lags.
+Autocorrelation of `x` at the given `lags` (demeaned). Kept under its
+historical name for interface stability.
 """
-function compute_partial_autocorrelation(x, lags)
-    return autocor(x, lags, demean=true)
-end
+compute_partial_autocorrelation(x, lags) = autocor(x, lags, demean = true)
 
 """
-    cocoBoot(cocoReg_fit, lags=[1:1:21;], n_bootstrap=400, alpha=0.05, n_burn_in=200, store_matrix = Array{Float64}(undef, length(lags), 2))
+    cocoBoot(cocoReg_fit, lags=[1:1:21;], n_bootstrap=400, alpha=0.05, n_burn_in=200)
 
-Bootstraps the partial autocorrelation function (PACF) for a fitted count regression model.
-It generates bootstrap samples of PACF values, computes quantiles to form confidence intervals,
-and then compares these intervals with the PACF computed from the observed data.
-
-# Arguments
-- `cocoReg_fit`: A dictionary containing the fitted model results.
-- `lags` (optional): A vector of lag values for which the PACF is computed (default is `[1:1:21;]`).
-- `n_bootstrap` (optional): The number of bootstrap replications (default is 400).
-- `alpha` (optional): The significance level for the confidence intervals (default is 0.05).
-- `n_burn_in` (optional): The number of burn-in samples to discard when simulating data (default is 200).
-- `store_matrix` (optional): A preallocated matrix to store the lower and upper quantiles for each lag.
-
-# Returns
-A dictionary with the following keys:
-- `"lower"`: The lower quantile values (first column) of the bootstrapped PACF for each lag.
-- `"upper"`: The upper quantile values (second column) of the bootstrapped PACF for each lag.
-- `"in_interval"`: A Boolean vector indicating if the observed PACF values lie within the bootstrap confidence intervals.
-- `"pacf_data"`: The PACF computed from the observed data.
-- `"pacfs"`: The matrix of bootstrapped PACF values.
-- `"lags"`: The vector of lag values.
+Parametric-bootstrap acceptance envelope of the autocorrelation function of a
+fitted model. Returns a `Dict` with keys `"lower"`, `"upper"`,
+`"in_interval"`, `"pacf_data"`, `"pacfs"` and `"lags"`.
 """
-function cocoBoot(cocoReg_fit, lags=[1:1:21;], n_bootstrap=400, alpha=0.05, n_burn_in=200, store_matrix = Array{Float64}(undef, length(lags), 2))
-    pacfs = compute_random_pacfs(cocoReg_fit, lags, Int(n_bootstrap), n_burn_in, Array{Float64}(undef, Int(n_bootstrap), length(lags)))
-    for i in 1:length(lags)
-        store_matrix[i, :] = quantile!(pacfs[:, i], [alpha/2, 1 - alpha/2])
+function cocoBoot(cocoReg_fit, lags = [1:1:21;], n_bootstrap = 400, alpha = 0.05,
+        n_burn_in = 200, store_matrix = Array{Float64}(undef, length(lags), 2))
+    pacfs = compute_random_pacfs(cocoReg_fit, lags, Int(n_bootstrap), Int(n_burn_in))
+    for i in eachindex(lags)
+        store_matrix[i, :] = quantile!(pacfs[:, i], [alpha / 2, 1 - alpha / 2])
     end
     pacf_data = compute_partial_autocorrelation(Int.(cocoReg_fit["data"]), lags)
-    return Dict("lower" => store_matrix[:, 1],
-                "upper" => store_matrix[:, 2],
-                "in_interval" => (store_matrix[:, 1] .< pacf_data) .& (store_matrix[:, 2] .> pacf_data),
-                "pacf_data" => pacf_data,
-                "pacfs" => pacfs,
-                "lags" => lags)
+    return Dict{String, Any}("lower" => store_matrix[:, 1],
+        "upper" => store_matrix[:, 2],
+        "in_interval" => (store_matrix[:, 1] .< pacf_data) .&
+                         (store_matrix[:, 2] .> pacf_data),
+        "pacf_data" => pacf_data,
+        "pacfs" => pacfs,
+        "lags" => lags)
 end
 
 """
-    compute_random_pacfs(cocoReg_fit, lags, n_bootstrap=400, n_burn_in=200, pacfs=Array{Float64}(undef, n_bootstrap, length(lags)))
+    compute_random_pacfs(cocoReg_fit, lags, n_bootstrap=400, n_burn_in=200)
 
-Generates bootstrapped partial autocorrelation coefficients by simulating new datasets from the fitted model.
-For each bootstrap iteration, it simulates data using `cocoSim` and computes the PACF for the specified lags.
-
-# Arguments
-- `cocoReg_fit`: A dictionary containing the fitted model parameters and observed data.
-- `lags`: A vector of lag values at which to compute the PACF.
-- `n_bootstrap` (optional): The number of bootstrap samples (default is 400).
-- `n_burn_in` (optional): The number of burn-in samples to discard during simulation (default is 200).
-- `pacfs` (optional): A preallocated matrix to store the PACF values from each bootstrap sample.
-
-# Returns
-A matrix of bootstrapped PACF values with dimensions `(n_bootstrap, length(lags))`.
+Autocorrelations of `n_bootstrap` datasets simulated from the fitted model.
+Returns an `(n_bootstrap, length(lags))` matrix.
 """
-function compute_random_pacfs(cocoReg_fit, lags, n_bootstrap=400, n_burn_in=200, pacfs=Array{Float64}(undef, n_bootstrap, length(lags)))
+function compute_random_pacfs(cocoReg_fit, lags, n_bootstrap = 400, n_burn_in = 200,
+        pacfs = Array{Float64}(undef, Int(n_bootstrap), length(lags)))
+    n = length(cocoReg_fit["data"])
     for b in 1:Int(n_bootstrap)
-        pacfs[b, :] = compute_partial_autocorrelation(cocoSim(cocoReg_fit["type"], Int(cocoReg_fit["order"]), cocoReg_fit["parameter"],
-                                                             length(cocoReg_fit["data"]), cocoReg_fit["covariates"], cocoReg_fit["link"],
-                                                             n_burn_in, zeros(length(cocoReg_fit["data"]) + n_burn_in)), lags)
+        simulated = cocoSim(cocoReg_fit["type"], Int(cocoReg_fit["order"]),
+            cocoReg_fit["parameter"], n, cocoReg_fit["covariates"],
+            cocoReg_fit["link"], n_burn_in, zeros(n + Int(n_burn_in)))
+        pacfs[b, :] = compute_partial_autocorrelation(simulated, lags)
     end
     return pacfs
 end
@@ -83,17 +52,11 @@ end
 """
     create_julia_dict(keys, values)
 
-Creates a Julia dictionary from arrays of keys and corresponding values.
-
-# Arguments
-- `keys`: An array containing the keys.
-- `values`: An array containing the values; each element corresponds to a key in `keys`.
-
-# Returns
-A dictionary mapping each key in `keys` to the corresponding value in `values`.
+Dictionary from parallel arrays of keys and values (used by the R bridge to
+synthesize a Julia fit object from an R-side fit).
 """
 function create_julia_dict(keys, values)
-    D = Dict()
+    D = Dict{Any, Any}()
     for i in eachindex(keys)
         D[keys[i]] = values[i]
     end

--- a/src/CocoPredict.jl
+++ b/src/CocoPredict.jl
@@ -1,189 +1,137 @@
-using FreqTables
-
 export cocoPredictOneStep, cocoForwardSim, cocoPredictKsteps
 
 """
-    cocoPredictOneStep(cocoReg_fit, x=0:10, covariates=nothing, safe_array = Array{Float64}(undef, length(x)))
+    cocoPredictOneStep(cocoReg_fit, x=0:10, covariates=nothing)
 
-Predicts one-step ahead count probabilities from a fitted count regression model.
+One-step-ahead predictive distribution of a fitted model over the candidate
+counts `x`. The full transition pmf is computed in a single pass and reused
+for the mode and median.
 
-# Arguments
-- `cocoReg_fit`: A dictionary containing fitted model information (e.g., data, parameters, order, type, link, etc.).
-- `x` (optional): A range or vector of possible future count values over which the prediction is computed (default is `0:10`).
-- `covariates` (optional): Optional covariate information used for prediction.
-- `safe_array` (optional): A preallocated array to store computed probabilities.
-
-# Returns
-A dictionary with:
-- `"probabilities"`: A vector of predicted probabilities for each count in `x`.
-- `"x"`: The input range of counts.
-- `"prediction_mode"`: The mode (most likely count) based on the maximum probability.
-- `"prediction_median"`: The median prediction computed from the cumulative probability.
+Returns a `Dict` with keys `"probabilities"`, `"x"`, `"prediction_mode"` and
+`"prediction_median"`.
 """
-function cocoPredictOneStep(cocoReg_fit, x=0:10, covariates=nothing, safe_array = Array{Float64}(undef, length(x)))
+function cocoPredictOneStep(cocoReg_fit, x = 0:10, covariates = nothing)
     lambda = get_lambda(cocoReg_fit, true)
-  
-    link_function = get_link_function(cocoReg_fit["link"])
-    if (!isnothing(covariates))
-        lambda = link_function(sum(covariates .* cocoReg_fit["parameter"][(end - size(cocoReg_fit["covariates"])[2] + 1):end]))
-    end
-  
-    if cocoReg_fit["order"] == 2
-        if cocoReg_fit["type"] == "Poisson"
-            eta = 0
-        else
-            eta = cocoReg_fit["parameter"][4]
-        end
-  
-        output = Dict("probabilities" => [compute_convolution_x_r_y_z(i, Int(cocoReg_fit["data"][end]),
-                                               Int(cocoReg_fit["data"][end-1]), lambda,
-                                               cocoReg_fit["parameter"][1], cocoReg_fit["parameter"][2],
-                                               cocoReg_fit["parameter"][3], eta,
-                                               cocoReg_fit["max_loop"]) for i in x],
-                      "prediction_mode" => -3.0)
-    elseif cocoReg_fit["order"] == 1
-        if cocoReg_fit["type"] == "Poisson"
-            eta = 0
-        else
-            eta = cocoReg_fit["parameter"][2]
-        end
-  
-        output = Dict("probabilities" => [compute_convolution_x_r_y(i, Int(cocoReg_fit["data"][end]),
-                                               lambda, cocoReg_fit["parameter"][1], eta) for i in x],
-                      "prediction_mode" => -3.0)
-    end
-  
-    output["x"] = x
-    output["prediction_mode"] = x[argmax(output["probabilities"])]
-    output["prediction_median"] = x[findfirst(cumsum(output["probabilities"]) .>= 0.5)]
-  
-    return output
-end
-
-"""
-    cocoForwardSim(n, x_prev, type, order, parameter, covariates=nothing, link="log", add_help=order * -1 + 2, x=zeros(Int(n + length(x_prev) + add_help)))
-
-Simulates forward count data for `n` steps given previous counts, model parameters, and optional covariates.
-
-# Arguments
-- `n`: The number of future steps to simulate.
-- `x_prev`: A vector of previous count values used for initializing the simulation.
-- `type`: A string indicating the model type (e.g., `"GP"` for generalized Poisson).
-- `order`: The autoregressive model order (1 or 2).
-- `parameter`: A vector of model parameters.
-- `covariates` (optional): A matrix of covariate data used in simulation.
-- `link` (optional): A string specifying the link function to use (default is `"log"`).
-- `add_help` (optional): A helper parameter for simulation (default computed as `order * -1 + 2`).
-- `x` (optional): A preallocated vector of integer counts with length `n + length(x_prev) + add_help`.
-
-# Returns
-A vector of simulated counts for the `n` forward steps.
-"""
-function cocoForwardSim(n, x_prev, type, order, parameter, covariates=nothing,
-                        link="log", add_help=order * -1 + 2,
-                        x=zeros(Int(n + length(x_prev) + add_help)))
-    n_burn_in = length(x_prev)
-    
-    if order == 2
-        x[end-1] = x_prev[end]
-        x[end-2] = x_prev[end-1]
-    else
-        x[end-1] = x_prev[end]
-    end
-  
-    link_function = get_link_function(link)
-    if order == 2
-        alpha1 = parameter[1]
-        alpha2 = parameter[2]
-        alpha3 = parameter[3]
-        alpha = nothing
-        if type == "GP"
-            eta = parameter[4]
-        else
-            eta = 0
-        end
-    else
-        alpha1 = nothing
-        alpha2 = nothing
-        alpha3 = nothing
-        alpha = parameter[1]
-        if type == "GP"
-            eta = parameter[2]
-        else
-            eta = 0
-        end
-    end
-  
     if !isnothing(covariates)
-        lambda = link_function.(covariates * parameter[Int((end - (size(covariates)[2] - 1))):Int(end)])
+        link_function = get_link_function(cocoReg_fit["link"])
+        n_betas = size(cocoReg_fit["covariates"], 2)
+        betas = cocoReg_fit["parameter"][(end - n_betas + 1):end]
+        lambda = link_function(sum(covariates .* betas))
+    end
+
+    parameter = cocoReg_fit["parameter"]
+    data = cocoReg_fit["data"]
+    xs = collect(Int, x)
+    xmax = maximum(xs)
+
+    if Int(cocoReg_fit["order"]) == 2
+        eta = cocoReg_fit["type"] == "Poisson" ? 0.0 : parameter[4]
+        y, z = Int(data[end]), Int(data[end - 1])
+        kernel = GP2Kernel(lambda, parameter[1], parameter[2], parameter[3], eta,
+            max(xmax, y + z))
+        pmf = convolution_pmf_vector(kernel, xmax, y, z, cocoReg_fit["max_loop"])
     else
-        lambda = repeat([last(parameter)], Int(n + n_burn_in + add_help))
+        eta = cocoReg_fit["type"] == "Poisson" ? 0.0 : parameter[2]
+        pmf = convolution_pmf_vector(xmax, Int(data[end]), lambda, parameter[1], eta)
     end
-  
-    for t in 3:(Int(n + n_burn_in + add_help))
-        x[t] = draw_random_g(order, rand(Uniform(0, 1), 1)[1], Int(x[t-1]), Int(x[t-2]), lambda[t-2], alpha1, alpha2, alpha3, alpha, eta, nothing) +
-               draw_random_generalized_poisson_variable(rand(Uniform(0, 1), 1)[1], lambda[t-2], eta)
-    end
-  
-    return x[Int((end - n + 1)):Int(end)]
+
+    probabilities = pmf[xs .+ 1]
+    return Dict{String, Any}("probabilities" => probabilities,
+        "x" => x,
+        "prediction_mode" => x[argmax(probabilities)],
+        "prediction_median" => x[findfirst(cumsum(probabilities) .>= 0.5)])
 end
 
 """
-    cocoPredictKsteps(cocoReg_fit, k, number_simulations=500, covariates=nothing, link="log", matrix_fill=zeros(Int64(number_simulations), Int64(k)))
+    cocoForwardSim(n, x_prev, type, order, parameter, covariates=nothing, link="log",
+                   add_help=order * -1 + 2, x=zeros(Int(n + length(x_prev) + add_help)))
 
-Generates a k-step ahead predictive distribution by simulating the model multiple times.
-
-# Arguments
-- `cocoReg_fit`: A dictionary containing the fitted model details.
-- `k`: The number of steps ahead to predict.
-- `number_simulations` (optional): The number of simulation runs to generate the predictive distribution (default is 500).
-- `covariates` (optional): Optional covariate data to use in the simulations.
-- `link` (optional): A string specifying the link function (default is `"log"`).
-- `matrix_fill` (optional): A preallocated matrix to store simulation results (default is a zeros matrix with dimensions `number_simulations` x `k`).
-
-# Returns
-A dictionary where each key `"prediction_i"` contains a DataFrame of count values and their relative frequencies for step `i`. Also includes a key `"length"` indicating the number of prediction steps.
+Simulates `n` steps forward from the trailing observations `x_prev` at the
+given parameter values.
 """
-function cocoPredictKsteps(cocoReg_fit, k, number_simulations=500,
-                           covariates=nothing,
-                           link="log",
-                           matrix_fill = zeros(Int64(number_simulations), Int64(k)))
+function cocoForwardSim(n, x_prev, type, order, parameter, covariates = nothing,
+        link = "log", add_help = Int(order) * -1 + 2,
+        x = zeros(Int(n + length(x_prev) + add_help)))
+    n = Int(n)
+    order = Int(order)
+    n_burn_in = length(x_prev)
+    n_total = n + n_burn_in + Int(add_help)
+
+    if order == 2
+        x[end - n - 1] = x_prev[end - 1]
+        x[end - n] = x_prev[end]
+    else
+        x[end - n] = x_prev[end]
+    end
+
+    if order == 2
+        alpha1, alpha2, alpha3 = parameter[1], parameter[2], parameter[3]
+        alpha = nothing
+        eta = type == "GP" ? parameter[4] : 0.0
+    else
+        alpha1 = alpha2 = alpha3 = nothing
+        alpha = parameter[1]
+        eta = type == "GP" ? parameter[2] : 0.0
+    end
+
+    link_function = get_link_function(link)
+    if !isnothing(covariates)
+        n_betas = size(covariates, 2)
+        lambda = link_function.(covariates * parameter[(end - n_betas + 1):end])
+    else
+        lambda = fill(float(last(parameter)), n_total)
+    end
+
+    for t in 3:n_total
+        x[t] = draw_random_g(order, rand(), Int(x[t - 1]), Int(x[t - 2]), lambda[t - 2],
+            alpha1, alpha2, alpha3, alpha, eta, nothing) +
+               draw_random_generalized_poisson_variable(rand(), lambda[t - 2], eta)
+    end
+
+    return x[(end - n + 1):end]
+end
+
+"""
+    cocoPredictKsteps(cocoReg_fit, k, number_simulations=500, covariates=nothing,
+                      link="log", matrix_fill=zeros(Int(number_simulations), Int(k)))
+
+k-step-ahead predictive distribution by parametric forward simulation.
+Returns a `Dict` with a `DataFrame` of values and relative frequencies per
+step (keys `"prediction_1"`, ..., plus `"length"`).
+"""
+function cocoPredictKsteps(cocoReg_fit, k, number_simulations = 500,
+        covariates = nothing, link = "log",
+        matrix_fill = zeros(Int(number_simulations), Int(k)))
     type = cocoReg_fit["type"]
-    order = cocoReg_fit["order"]
+    order = Int(cocoReg_fit["order"])
     parameter = cocoReg_fit["parameter"]
     link = cocoReg_fit["link"]
-    
-    x_prev = cocoReg_fit["data"][end]
-    if order == 2
-        x_prev = cocoReg_fit["data"][(end-1):end]
+    data = cocoReg_fit["data"]
+
+    x_prev = order == 2 ? data[(end - 1):end] : data[end]
+
+    for i in 1:Int(number_simulations)
+        matrix_fill[i, :] = cocoForwardSim(k, x_prev, type, order, parameter,
+            covariates, link)
     end
-  
-    for i in 1:Int64(number_simulations)
-        matrix_fill[i, :] = cocoForwardSim(k, x_prev, type, order, parameter, covariates, link)
-    end
-  
+
     return get_relative_frequencies(matrix_fill)
 end
 
 """
     get_relative_frequencies(matrix)
 
-Computes the relative frequencies of simulated count predictions for each prediction step.
-
-# Arguments
-- `matrix`: A matrix of simulated count predictions, where each column corresponds to a prediction step.
-
-# Returns
-A dictionary where each key `"prediction_i"` contains a DataFrame with two columns:
-- `"value"`: The unique count values.
-- `"frequency"`: The relative frequency of each count (normalized by the number of simulations).
-Also includes a key `"length"` indicating the number of prediction steps.
+Relative frequencies of the simulated predictions per step (matrix column).
+Returns a `Dict` with a `DataFrame` per step plus a `"length"` entry.
 """
 function get_relative_frequencies(matrix)
-    out = Dict()
-    for i in 1:size(matrix)[2]
+    out = Dict{String, Any}()
+    n_simulations = size(matrix, 1)
+    for i in 1:size(matrix, 2)
         freq_table = freqtable(matrix[:, i])
-        out["prediction_$i"] = DataFrame(hcat(names(freq_table)[1], freq_table ./ size(matrix)[1]), ["value", "frequency"])
+        out["prediction_$i"] = DataFrame(
+            hcat(names(freq_table)[1], freq_table ./ n_simulations),
+            ["value", "frequency"])
     end
     out["length"] = length(out)
     return out

--- a/src/CocoReg.jl
+++ b/src/CocoReg.jl
@@ -1,292 +1,278 @@
-using Optim, LineSearches, ForwardDiff, Base.Threads
-
 export cocoReg
 
-"""
-    minimize_pars_reparameterization_GP2(theta, data, covariates=nothing, link="log", max=nothing)
+function _validate_reg_inputs(type, order)
+    type in ("GP", "Poisson") ||
+        throw(ArgumentError("type must be \"GP\" or \"Poisson\", got \"$type\""))
+    Int(order) in (1, 2) || throw(ArgumentError("order must be 1 or 2, got $order"))
+    return Int(order)
+end
 
-Computes the negative log-likelihood for a second-order generalized Poisson (GP2) model using reparameterized alpha parameters.
-This function constructs the rate parameter vector `lambdas` using a link function and the provided covariates (if any), 
-reparameterizes the autoregressive parameters via `reparameterize_alpha(theta)`, and then evaluates the negative log-lelihood.
+function _n_parameters_without_covariates(type, order)
+    Int(order) == 1 ? (type == "GP" ? 2 : 1) : (type == "GP" ? 4 : 3)
+end
 
-# Arguments
-- `theta`: A vector of parameters. For GP2, `theta[4]` represents the dispersion parameter (eta) and `theta[5]` onward are used for lambda.
-- `data`: A vector of observed counts.
-- `covariates` (optional): A matrix of covariates used to adjust the rate parameter.
-- `link`: (optional) A string specifying the link function (default is `"log"`).
-- `max`: (optional) A parameter controlling the iteration limit in the likelihood computation.
-
-# Returns
-The negative log-likelihood value computed by `compute_negative_log_likelihood_GP2`.
-"""
-function minimize_pars_reparameterization_GP2(theta, data, covariates=nothing, link="log", max=nothing)
-    link_function = get_link_function(link)
-    lambdas = repeat([theta[5]], length(data))
-    if !isnothing(covariates)
-        lambdas .= link_function.(covariates * theta[5:5+(size(covariates, 2)-1)])
-    end
-
-    alpha1, alpha2, alpha3 = reparameterize_alpha(theta)
-    
-    return compute_negative_log_likelihood_GP2(lambdas, alpha1, alpha2, alpha3, theta[4], data, max)
+function _lambda_vector(theta, first_index::Int, covariates, link_function::F) where {F}
+    n_betas = size(covariates, 2)
+    return link_function.(covariates * view(theta, first_index:(first_index + n_betas - 1)))
 end
 
 """
-    minimize_pars_reparameterization_Poisson2(theta, data, covariates=nothing, link="log", max=nothing)
+    _make_objective(type, order, data, covariates, link_function, max_loop, reparameterized)
 
-Computes the negative log-likelihood for a second-order Poisson model using reparameterized alpha parameters.
-The function constructs the rate parameter vector `lambdas` using the link function and covariates (if provided),
-reparameterizes the autoregressive parameters, and evaluates the negative log-likelihood with dispersion set to zero.
-
-# Arguments
-- `theta`: A parameter vector where `theta[4]` is used for the base lambda.
-- `data`: A vector of observed counts.
-- `covariates` (optional): A matrix of covariates.
-- `link`: (optional) The link function to use (default is `"log"`).
-- `max`: (optional) Parameter to control iteration limits in the likelihood computation.
-
-# Returns
-The negative log-likelihood value computed by `compute_negative_log_likelihood_GP2` with eta set to 0.
+Builds the negative log-likelihood objective `theta -> nll(theta)` for the
+requested model. For constant-rate models the unique data transitions and
+their multiplicities are precomputed once here, outside the optimization
+loop, so every objective evaluation only pays for distinct transition
+probabilities. `reparameterized` selects the stationarity-preserving
+reparameterization of the second-order alphas used during optimization.
 """
-function minimize_pars_reparameterization_Poisson2(theta, data, covariates=nothing, link="log", max=nothing)
-    link_function = get_link_function(link)
-    lambdas = repeat([theta[4]], length(data))
-    if !isnothing(covariates)
-        lambdas .= link_function.(covariates * theta[4:4+(size(covariates, 2)-1)])
-    end
-
-    alpha1, alpha2, alpha3 = reparameterize_alpha(theta)
-    
-    return compute_negative_log_likelihood_GP2(lambdas, alpha1, alpha2, alpha3, 0, data, max)
-end
-
-"""
-    minimize_pars_GP2(theta, data, covariates=nothing, link="log", max=nothing)
-
-Computes the negative log-likelihood for a second-order generalized Poisson (GP2) model using the provided parameters.
-The lambda vector is computed from `theta[5]` and adjusted by covariates if available, and the likelihood is evaluated using 
-`compute_negative_log_likelihood_GP2`.
-
-# Arguments
-- `theta`: A vector of parameters where `theta[1:3]` are the autoregressive parameters, `theta[4]` is the dispersion parameter (eta),
-  and `theta[5]` onward are used for lambda computation.
-- `data`: A vector of observed counts.
-- `covariates` (optional): A matrix of covariates.
-- `link`: (optional) The link function to apply (default is `"log"`).
-- `max`: (optional) A parameter controlling iteration limits in likelihood computation.
-
-# Returns
-The negative log-likelihood value for the GP2 model.
-"""
-function minimize_pars_GP2(theta, data, covariates=nothing, link="log", max=nothing)
-    link_function = get_link_function(link)
-    lambdas = repeat([theta[5]], length(data))
-    if !isnothing(covariates)
-        lambdas .= link_function.(covariates * theta[5:5+(size(covariates, 2)-1)])
-    end
-
-    return compute_negative_log_likelihood_GP2(lambdas, theta[1], theta[2], theta[3], theta[4], data, max)
-end
-
-"""
-    minimize_pars_Poisson2(theta, data, covariates=nothing, link="log", max=nothing)
-
-Computes the negative log-likelihood for a second-order Poisson model using the provided parameters.
-The lambda vector is computed from `theta[4]` (and adjusted by covariates if provided) while the dispersion is set to 0.
-
-# Arguments
-- `theta`: A vector of parameters where `theta[1:3]` are the autoregressive parameters and `theta[4]` is used for the base lambda.
-- `data`: A vector of observed counts.
-- `covariates` (optional): A matrix of covariates.
-- `link`: (optional) The link function to use (default is `"log"`).
-- `max`: (optional) Parameter to control iteration limits in the likelihood computation.
-
-# Returns
-The negative log-likelihood value for the second-order Poisson model.
-"""
-function minimize_pars_Poisson2(theta, data, covariates=nothing, link="log", max=nothing)
-    link_function = get_link_function(link)
-    lambdas = repeat([theta[4]], length(data))
-    if !isnothing(covariates)
-        lambdas .= link_function.(covariates * theta[4:4+(size(covariates, 2)-1)])
-    end
-
-    return compute_negative_log_likelihood_GP2(lambdas, theta[1], theta[2], theta[3], 0, data, max)
-end
-
-"""
-    minimize_pars_GP1(theta, data, covariates=nothing, link="log", max=nothing)
-
-Computes the negative log-likelihood for a first-order generalized Poisson (GP1) model.
-The lambda vector is computed from `theta[3]` and adjusted by covariates if available. 
-It then evaluates the likelihood using `compute_negative_log_likelihood_GP1` with `theta[1]` as the autoregressive parameter 
-and `theta[2]` as the dispersion parameter.
-
-# Arguments
-- `theta`: A vector of parameters where `theta[1]` is the autoregressive parameter, `theta[2]` is the dispersion parameter (eta),
-  and `theta[3]` onward are used for lambda computation.
-- `data`: A vector of observed counts.
-- `covariates` (optional): A matrix of covariates.
-- `link`: (optional) The link function (default is `"log"`).
-- `max`: (optional) Not used in this model (included for consistency).
-
-# Returns
-The negative log-likelihood for the first-order GP model.
-"""
-function minimize_pars_GP1(theta, data, covariates=nothing, link="log", max=nothing)
-    link_function = get_link_function(link)
-    lambdas = repeat([theta[3]], length(data))
-    if !isnothing(covariates)
-        lambdas .= link_function.(covariates * theta[3:3+(size(covariates, 2)-1)])
-    end
-
-    return compute_negative_log_likelihood_GP1(lambdas, theta[1], theta[2], data)
-end
-
-"""
-    minimize_pars_Poisson1(theta, data, covariates=nothing, link="log", max=nothing)
-
-Computes the negative log-likelihood for a first-order Poisson model.
-The lambda vector is computed from `theta[2]` (and adjusted by covariates if provided) while the dispersion is set to 0.
-
-# Arguments
-- `theta`: A vector of parameters where `theta[1]` is the autoregressive parameter and `theta[2]` onward are used for lambda computation.
-- `data`: A vector of observed counts.
-- `covariates` (optional): A matrix of covariates.
-- `link`: (optional) The link function to use (default is `"log"`).
-- `max`: (optional) Not used in this model (included for consistency).
-
-# Returns
-The negative log-likelihood for the first-order Poisson model.
-"""
-function minimize_pars_Poisson1(theta, data, covariates=nothing, link="log", max=nothing)
-    link_function = get_link_function(link)
-    lambdas = repeat([theta[2]], length(data))
-    if !isnothing(covariates)
-        lambdas .= link_function.(covariates * theta[2:2+(size(covariates, 2)-1)])
-    end
-
-    return compute_negative_log_likelihood_GP1(lambdas, theta[1], 0, data)
-end
-
-"""
-    cocoReg(type, order, data, covariates=nothing, starting_values=nothing, link_function="log", lower_bound_covariates=-Inf, max_loop=nothing, optimizer=Fminbox(LBFGS()))
-
-Fits a count regression model using either a generalized Poisson or Poisson likelihood based on the specified type and order.
-The function sets up the optimization problem, determines starting values and parameter bounds, 
-and minimizes the negative log-likelihood using an automatic differentiation optimizer.
-
-# Arguments
-- `type`: A string indicating the model type ("GP" for generalized Poisson, "Poisson" for Poisson).
-- `order`: The autoregressive order (1 or 2).
-- `data`: A vector of observed counts.
-- `covariates` (optional): A matrix of covariate values.
-- `starting_values` (optional): Initial values for the optimizer.
-- `link_function` (optional): A string specifying the link function (default is `"log"`).
-- `lower_bound_covariates` (optional): Lower bound for covariate parameters (default is `-Inf`).
-- `max_loop` (optional): Parameter controlling the maximum iteration or truncation in likelihood computation.
-- `optimizer` (optional): The optimization algorithm to use (default is `Fminbox(LBFGS())`).
-
-# Returns
-A dictionary containing:
-- `"parameter"`: The fitted parameter vector.
-- `"covariance_matrix"`: The inverse Hessian matrix as an estimate of the parameter covariance.
-- `"log_likelihood"`: The log-likelihood value at the optimum.
-- Model details including `type`, `order`, `data`, `covariates`, `link`, starting values, optimizer settings, and parameter bounds.
-- `"se"`: The standard errors of the estimated parameters.
-"""
-function cocoReg(type, order, data, covariates=nothing, starting_values=nothing,
-                  link_function="log", lower_bound_covariates=-Inf, max_loop=nothing,
-                  optimizer=Fminbox(LBFGS()))
-    
-    #-------------------------start dependent on type----------------------------------------------------------
-    if order == 2
-        if type == "GP"
-            starting_values = get_starting_values!(type, order, Int.(data), covariates, starting_values, 4, lower_bound_covariates)
-            fn = OnceDifferentiable(theta -> minimize_pars_reparameterization_GP2(theta, Int.(data),
-                                                                                covariates,
-                                                                                link_function,
-                                                                                max_loop),
-                                    starting_values,
-                                    autodiff=:forward)
-            f_alphas = theta -> minimize_pars_GP2(theta, Int.(data), covariates,
-                                                  link_function, max_loop)
-        elseif type == "Poisson"
-            starting_values = get_starting_values!(type, order, Int.(data), covariates, starting_values, 3, lower_bound_covariates)
-            fn = OnceDifferentiable(theta -> minimize_pars_reparameterization_Poisson2(theta, Int.(data),
-                                                                                covariates,
-                                                                                link_function,
-                                                                                max_loop),
-                                    starting_values,
-                                    autodiff=:forward)
-            f_alphas = theta -> minimize_pars_Poisson2(theta, Int.(data), covariates,
-                                                      link_function, max_loop)
+function _make_objective(type, order, data::Vector{Int}, covariates, link_function,
+        max_loop, reparameterized::Bool)
+    is_gp = type == "GP"
+    if covariates === nothing
+        transitions, counts = _transition_counts(data, order)
+        if Int(order) == 1
+            if is_gp
+                return theta -> _nll_gp1_transitions(theta[3], theta[1], theta[2],
+                    transitions, counts)
+            end
+            return theta -> _nll_gp1_transitions(theta[2], theta[1],
+                zero(eltype(theta)), transitions, counts)
+        end
+        max_index = _gp2_max_index(transitions)
+        lambda_index = is_gp ? 5 : 4
+        return function (theta)
+            alpha1, alpha2, alpha3 = reparameterized ? reparameterize_alpha(theta) :
+                                     (theta[1], theta[2], theta[3])
+            eta = is_gp ? theta[4] : zero(eltype(theta))
+            return _nll_gp2_transitions(theta[lambda_index], alpha1, alpha2, alpha3,
+                eta, transitions, counts, max_index, max_loop)
         end
     end
-    #-----------------------------------------Order 1 models-------------------------
-    if order == 1
-        if type == "GP"
-            starting_values = get_starting_values!(type, order, Int.(data), covariates, starting_values, 2, lower_bound_covariates)
-            fn = OnceDifferentiable(theta -> minimize_pars_GP1(theta, Int.(data),
-                                                                covariates,
-                                                                link_function),
-                                    starting_values,
-                                    autodiff=:forward)
-            f_alphas = theta -> minimize_pars_GP1(theta, Int.(data), covariates,
-                                                  link_function)
-        elseif type == "Poisson"
-            starting_values = get_starting_values!(type, order, Int.(data), covariates, starting_values, 1, lower_bound_covariates)
-            fn = OnceDifferentiable(theta -> minimize_pars_Poisson1(theta, Int.(data),
-                                                                     covariates,
-                                                                     link_function),
-                                    starting_values,
-                                    autodiff=:forward)
-            f_alphas = theta -> minimize_pars_Poisson1(theta, Int.(data), covariates,
-                                                      link_function)
+    link = get_link_function(link_function)
+    if Int(order) == 1
+        lambda_index = is_gp ? 3 : 2
+        return function (theta)
+            lambdas = _lambda_vector(theta, lambda_index, covariates, link)
+            eta = is_gp ? theta[2] : zero(eltype(theta))
+            return compute_negative_log_likelihood_GP1(lambdas, theta[1], eta, data)
         end
     end
-    #--------------------------end dependent on type
+    lambda_index = is_gp ? 5 : 4
+    return function (theta)
+        lambdas = _lambda_vector(theta, lambda_index, covariates, link)
+        alpha1, alpha2, alpha3 = reparameterized ? reparameterize_alpha(theta) :
+                                 (theta[1], theta[2], theta[3])
+        eta = is_gp ? theta[4] : zero(eltype(theta))
+        return compute_negative_log_likelihood_GP2(lambdas, alpha1, alpha2, alpha3, eta,
+            data, max_loop)
+    end
+end
 
-    # Write down constraints
+# Backward-compatible objective wrappers (parameter layouts documented in cocoReg).
+function minimize_pars_GP1(theta, data, covariates = nothing, link = "log",
+        max_loop = nothing)
+    if covariates === nothing
+        return compute_negative_log_likelihood_GP1(theta[3], theta[1], theta[2],
+            Int.(data))
+    end
+    lambdas = _lambda_vector(theta, 3, covariates, get_link_function(link))
+    return compute_negative_log_likelihood_GP1(lambdas, theta[1], theta[2], Int.(data))
+end
+
+function minimize_pars_Poisson1(theta, data, covariates = nothing, link = "log",
+        max_loop = nothing)
+    eta = zero(eltype(theta))
+    if covariates === nothing
+        return compute_negative_log_likelihood_GP1(theta[2], theta[1], eta, Int.(data))
+    end
+    lambdas = _lambda_vector(theta, 2, covariates, get_link_function(link))
+    return compute_negative_log_likelihood_GP1(lambdas, theta[1], eta, Int.(data))
+end
+
+function minimize_pars_GP2(theta, data, covariates = nothing, link = "log",
+        max_loop = nothing)
+    if covariates === nothing
+        return compute_negative_log_likelihood_GP2(theta[5], theta[1], theta[2],
+            theta[3], theta[4], Int.(data), max_loop)
+    end
+    lambdas = _lambda_vector(theta, 5, covariates, get_link_function(link))
+    return compute_negative_log_likelihood_GP2(lambdas, theta[1], theta[2], theta[3],
+        theta[4], Int.(data), max_loop)
+end
+
+function minimize_pars_Poisson2(theta, data, covariates = nothing, link = "log",
+        max_loop = nothing)
+    eta = zero(eltype(theta))
+    if covariates === nothing
+        return compute_negative_log_likelihood_GP2(theta[4], theta[1], theta[2],
+            theta[3], eta, Int.(data), max_loop)
+    end
+    lambdas = _lambda_vector(theta, 4, covariates, get_link_function(link))
+    return compute_negative_log_likelihood_GP2(lambdas, theta[1], theta[2], theta[3],
+        eta, Int.(data), max_loop)
+end
+
+function minimize_pars_reparameterization_GP2(theta, data, covariates = nothing,
+        link = "log", max_loop = nothing)
+    alpha1, alpha2, alpha3 = reparameterize_alpha(theta)
+    if covariates === nothing
+        return compute_negative_log_likelihood_GP2(theta[5], alpha1, alpha2, alpha3,
+            theta[4], Int.(data), max_loop)
+    end
+    lambdas = _lambda_vector(theta, 5, covariates, get_link_function(link))
+    return compute_negative_log_likelihood_GP2(lambdas, alpha1, alpha2, alpha3,
+        theta[4], Int.(data), max_loop)
+end
+
+function minimize_pars_reparameterization_Poisson2(theta, data, covariates = nothing,
+        link = "log", max_loop = nothing)
+    alpha1, alpha2, alpha3 = reparameterize_alpha(theta)
+    eta = zero(eltype(theta))
+    if covariates === nothing
+        return compute_negative_log_likelihood_GP2(theta[4], alpha1, alpha2, alpha3,
+            eta, Int.(data), max_loop)
+    end
+    lambdas = _lambda_vector(theta, 4, covariates, get_link_function(link))
+    return compute_negative_log_likelihood_GP2(lambdas, alpha1, alpha2, alpha3, eta,
+        Int.(data), max_loop)
+end
+
+_logistic(u::Real) = 1 / (1 + exp(-u))
+_logit(x::Real) = log(x) - log1p(-x)
+
+"""
+    _to_bounded(u, lower, upper)
+
+Maps the unconstrained value `u` into `(lower, upper)`: logistic scaling for
+two-sided bounds, `lower + exp(u)` / `upper - exp(u)` for one-sided bounds,
+identity when unbounded. Smooth in `u`, so any AD backend differentiates
+through it.
+"""
+function _to_bounded(u::Real, lower::Real, upper::Real)
+    if isfinite(lower) && isfinite(upper)
+        return lower + (upper - lower) * _logistic(u)
+    elseif isfinite(lower)
+        return lower + exp(u)
+    elseif isfinite(upper)
+        return upper - exp(u)
+    end
+    return u
+end
+
+"""
+    _to_unconstrained(x, lower, upper)
+
+Inverse of [`_to_bounded`](@ref); values at (or numerically outside) the
+bounds are pulled strictly inside before transforming.
+"""
+function _to_unconstrained(x::Real, lower::Real, upper::Real)
+    margin = 1e-8
+    if isfinite(lower) && isfinite(upper)
+        return _logit(clamp((x - lower) / (upper - lower), margin, 1 - margin))
+    elseif isfinite(lower)
+        return log(max(x - lower, margin))
+    elseif isfinite(upper)
+        return log(max(upper - x, margin))
+    end
+    return x
+end
+
+"""
+    cocoReg(type, order, data, covariates=nothing, starting_values=nothing,
+            link_function="log", lower_bound_covariates=-Inf, max_loop=nothing,
+            optimizer=nothing; adtype=Optimization.AutoForwardDiff(),
+            box_constrained=false, solve_kwargs...)
+
+Fits a (Generalized) Poisson autoregressive count model of the given `order`
+by maximum likelihood.
+
+The optimization runs through the Optimization.jl interface: the objective is
+wrapped in an `OptimizationFunction` with the automatic-differentiation
+backend `adtype` (any `ADTypes.AbstractADType`, e.g.
+`Optimization.AutoForwardDiff()` or — with Enzyme loaded — `AutoEnzyme()`).
+Extra keyword arguments are forwarded to `Optimization.solve` (e.g.
+`maxiters`, `reltol`).
+
+By default the parameter constraints are handled by smooth parameter
+transformations (logistic for two-sided bounds, shifted `exp` for one-sided
+bounds) and the problem is solved unconstrained with `optimizer` (default:
+`LBFGS()` from Optim.jl; any unconstrained Optimization.jl solver works).
+With `box_constrained = true` the constraints are passed to the solver as box
+bounds instead (default solver then: `Fminbox(LBFGS())`).
+
+For second-order models the optimizer additionally works on a
+stationarity-preserving reparameterization of the alphas; the returned
+parameters, covariance matrix and standard errors are always on the original
+scale.
+
+Returns a `Dict` with keys `"parameter"`, `"covariance_matrix"`, `"se"`,
+`"log_likelihood"`, `"type"`, `"order"`, `"data"`, `"covariates"`, `"link"`,
+`"starting_values"`, `"optimizer"`, `"lower_bounds"`, `"upper_bounds"`,
+`"optimization"` and `"max_loop"`.
+"""
+function cocoReg(type, order, data, covariates = nothing, starting_values = nothing,
+        link_function = "log", lower_bound_covariates = -Inf, max_loop = nothing,
+        optimizer = nothing; adtype = Optimization.AutoForwardDiff(),
+        box_constrained::Bool = false, solve_kwargs...)
+    order = _validate_reg_inputs(type, order)
+    data_int = Int.(data)
+
+    starting_values = get_starting_values!(type, order, data_int, covariates,
+        starting_values, _n_parameters_without_covariates(type, order),
+        lower_bound_covariates)
     lower, upper = get_bounds(order, type, covariates, lower_bound_covariates)
-    
-    # Obtain fit
-    fit = optimize(fn, lower, upper, starting_values, optimizer)
-    parameter = Optim.minimizer(fit)
-    
-    # Get alphas from reparameterized results
+
+    objective = _make_objective(type, order, data_int, covariates, link_function,
+        max_loop, order == 2)
+    f_alphas = _make_objective(type, order, data_int, covariates, link_function,
+        max_loop, false)
+
+    if box_constrained
+        optimizer = optimizer === nothing ? Fminbox(LBFGS()) : optimizer
+        optimization_function = OptimizationFunction((theta, _) -> objective(theta),
+            adtype)
+        problem = OptimizationProblem(optimization_function, Float64.(starting_values);
+            lb = Float64.(lower), ub = Float64.(upper))
+        solution = solve(problem, optimizer; solve_kwargs...)
+        parameter = copy(solution.u)
+    else
+        optimizer = optimizer === nothing ? LBFGS() : optimizer
+        lo, hi = Float64.(lower), Float64.(upper)
+        u0 = _to_unconstrained.(Float64.(starting_values), lo, hi)
+        optimization_function = OptimizationFunction(
+            (u, _) -> objective(_to_bounded.(u, lo, hi)), adtype)
+        problem = OptimizationProblem(optimization_function, u0)
+        solution = solve(problem, optimizer; solve_kwargs...)
+        parameter = _to_bounded.(solution.u, lo, hi)
+    end
+
     if order == 2
         alpha1, alpha2, alpha3 = reparameterize_alpha(parameter)
         parameter[1:3] = [alpha1, alpha2, alpha3]
     end
-    
 
     inv_hessian = compute_inverse_matrix(compute_hessian(f_alphas, parameter))
-    if any(diag(inv_hessian) .< 0)
-        for i in 1:size(inv_hessian, 1)
-            if inv_hessian[i, i] < 0
-                inv_hessian[i, i] = 10^-12
-            end
+    for i in 1:size(inv_hessian, 1)
+        if inv_hessian[i, i] < 0
+            inv_hessian[i, i] = 1e-12
         end
-    end  
-    
-    # Construct output
-    out = Dict("parameter" => parameter,
-               "covariance_matrix" => inv_hessian,
-               "log_likelihood" => -f_alphas(parameter),
-               "type" => type,
-               "order" => order,
-               "data" => data,
-               "covariates" => covariates,
-               "link" => link_function,
-               "starting_values" => starting_values,
-               "optimizer" => optimizer,
-               "lower_bounds" => lower,
-               "upper_bounds" => upper,
-               "optimization" => fit,
-               "max_loop" => max_loop)
-    
-    # Compute standard errors
-    out["se"] = diag(out["covariance_matrix"]).^0.5
+    end
+
+    out = Dict{String, Any}("parameter" => parameter,
+        "covariance_matrix" => inv_hessian,
+        "log_likelihood" => -f_alphas(parameter),
+        "type" => type,
+        "order" => order,
+        "data" => data,
+        "covariates" => covariates,
+        "link" => link_function,
+        "starting_values" => starting_values,
+        "optimizer" => optimizer,
+        "lower_bounds" => lower,
+        "upper_bounds" => upper,
+        "optimization" => solution,
+        "max_loop" => max_loop)
+    out["se"] = sqrt.(diag(inv_hessian))
     return out
 end

--- a/src/CocoReg.jl
+++ b/src/CocoReg.jl
@@ -30,8 +30,8 @@ function _make_objective(type, order, data::Vector{Int}, covariates, link_functi
         max_loop, reparameterized::Bool)
     is_gp = type == "GP"
     if covariates === nothing
-        transitions, counts = _transition_counts(data, order)
         if Int(order) == 1
+            transitions, counts = _transition_pair_counts(data)
             if is_gp
                 return theta -> _nll_gp1_transitions(theta[3], theta[1], theta[2],
                     transitions, counts)
@@ -39,14 +39,16 @@ function _make_objective(type, order, data::Vector{Int}, covariates, link_functi
             return theta -> _nll_gp1_transitions(theta[2], theta[1],
                 zero(eltype(theta)), transitions, counts)
         end
+        transitions, counts = _transition_triple_counts(data)
         max_index = _gp2_max_index(transitions)
+        groups = _group_transitions(transitions, counts)
         lambda_index = is_gp ? 5 : 4
         return function (theta)
             alpha1, alpha2, alpha3 = reparameterized ? reparameterize_alpha(theta) :
                                      (theta[1], theta[2], theta[3])
             eta = is_gp ? theta[4] : zero(eltype(theta))
             return _nll_gp2_transitions(theta[lambda_index], alpha1, alpha2, alpha3,
-                eta, transitions, counts, max_index, max_loop)
+                eta, groups, max_index, max_loop)
         end
     end
     link = get_link_function(link_function)

--- a/src/CocoSim.jl
+++ b/src/CocoSim.jl
@@ -1,179 +1,119 @@
-using Random, Distributions, StatsBase, DataFrames
-
 export cocoSim
+
+const _MAX_INVERSE_TRANSFORM_ITERATIONS = 1_000_000
 
 """
     draw_random_generalized_poisson_variable(u, lambda, eta)
 
-Generates a random draw from the generalized Poisson distribution using inverse transform sampling.
-
-# Arguments
-- `u`: A uniform random value in [0, 1] used as the threshold for the cumulative probability.
-- `lambda`: The rate parameter of the generalized Poisson distribution.
-- `eta`: The dispersion parameter of the generalized Poisson distribution.
-
-# Returns
-An integer value sampled from the generalized Poisson distribution.
+Draws from the Generalized Poisson distribution by inverse-transform sampling
+of the uniform variate `u`.
 """
-function draw_random_generalized_poisson_variable(u, lambda, eta)
-    sum = 0.0
+function draw_random_generalized_poisson_variable(u::Real, lambda::Real, eta::Real)
+    cumulative = generalized_poisson_distribution(0, lambda, eta)
     i = 0
-    while sum < u
-        sum = sum + generalized_poisson_distribution(i, lambda, eta)
-        i = i + 1
+    while cumulative < u && i < _MAX_INVERSE_TRANSFORM_ITERATIONS
+        i += 1
+        cumulative += generalized_poisson_distribution(i, lambda, eta)
     end
-    return i - 1
+    return i
 end
-
-
-"""
-    draw_random_g_r_y_z_variable(u, y, z, lambda, alpha1, alpha2, alpha3, eta, max)
-
-Generates a random draw from a custom discrete distribution defined by the function `compute_g_r_y_z` using inverse transform sampling. This function is designed for models incorporating two autoregressive lags.
-
-# Arguments
-- `u`: A uniform random value in [0, 1] serving as the threshold.
-- `y`: A model parameter (e.g., a previous count) used in the computation.
-- `z`: A second model parameter (e.g., another lagged count).
-- `lambda`: The rate parameter used in the distribution.
-- `alpha1`: The first autoregressive parameter.
-- `alpha2`: The second autoregressive parameter.
-- `alpha3`: The third autoregressive parameter.
-- `eta`: A dispersion parameter.
-- `max`: A parameter that may set an upper limit or truncation value in the computation.
-
-# Returns
-An integer sampled from the custom distribution defined by `compute_g_r_y_z`.
-"""
-function draw_random_g_r_y_z_variable(u, y, z, lambda, alpha1, alpha2, alpha3, eta, max)
-    sum = 0.0
-    i = 0
-    while sum < u
-        sum = sum + compute_g_r_y_z(i, y, z, lambda, alpha1, alpha2, alpha3, eta, max)
-        i = i + 1
-    end
-    return i - 1
-end
-
 
 """
     draw_random_g_r_y_variable(u, y, alpha, eta, lambda)
 
-Generates a random draw from a custom discrete distribution defined by the function `compute_g_r_y` using inverse transform sampling. This is intended for models with a single autoregressive parameter.
-
-# Arguments
-- `u`: A uniform random value in [0, 1] used as the sampling threshold.
-- `y`: A model parameter (typically representing a lagged count).
-- `alpha`: The autoregressive parameter for the model.
-- `eta`: A dispersion parameter.
-- `lambda`: The rate parameter for the distribution.
-
-# Returns
-An integer value sampled from the distribution defined by `compute_g_r_y`.
+Draws from the first-order convolution distribution `g(r | y)` by
+inverse-transform sampling. The support is `0:y`.
 """
-function draw_random_g_r_y_variable(u, y, alpha, eta, lambda)
-    sum = 0.0
+function draw_random_g_r_y_variable(u::Real, y::Integer, alpha::Real, eta::Real,
+        lambda::Real)
+    cumulative = compute_g_r_y(y, 0, alpha, eta, lambda)
     i = 0
-    while sum < u
-        sum = sum + compute_g_r_y(y, i, alpha, eta, lambda)
-        i = i + 1
+    while cumulative < u && i < y
+        i += 1
+        cumulative += compute_g_r_y(y, i, alpha, eta, lambda)
     end
-    return i - 1
+    return i
 end
 
 """
-    draw_random_g(order, u, y, z, lambda, alpha1, alpha2, alpha3, alpha, eta, max)
+    draw_random_g_r_y_z_variable(u, y, z, lambda, alpha1, alpha2, alpha3, eta, max_loop)
 
-Draws a random variable from one of two custom distributions depending on the specified model order.
-
-- If `order == 1`, it calls `draw_random_g_r_y_variable`.
-- If `order == 2`, it calls `draw_random_g_r_y_z_variable`.
-
-# Arguments
-- `order`: An integer specifying the order of the model (1 for single-lag, 2 for two-lag).
-- `u`: A uniform random value in [0, 1] used as the threshold.
-- `y`: A model parameter (typically a lagged count).
-- `z`: A secondary model parameter required for order 2 models.
-- `lambda`: The rate parameter for the distribution.
-- `alpha1`: First autoregressive parameter (for order 2).
-- `alpha2`: Second autoregressive parameter (for order 2).
-- `alpha3`: Third autoregressive parameter (for order 2).
-- `alpha`: Autoregressive parameter used for order 1.
-- `eta`: A dispersion parameter.
-- `max`: A parameter used in the custom distribution for order 2.
-
-# Returns
-An integer representing the sampled value from the chosen distribution.
+Draws from the second-order convolution distribution `g(r | y, z)` by
+inverse-transform sampling. The kernel tables and the bivariate normalizer are
+built once per draw instead of once per candidate value. The support is
+`0:(y + z)`.
 """
-function draw_random_g(order, u, y, z, lambda, alpha1, alpha2, alpha3, alpha, eta, max)
-    if order == 1
+function draw_random_g_r_y_z_variable(u::Real, y::Integer, z::Integer, lambda::Real,
+        alpha1::Real, alpha2::Real, alpha3::Real, eta::Real, max_loop)
+    kernel = GP2Kernel(lambda, alpha1, alpha2, alpha3, eta, y + z)
+    smax = max_loop === nothing ? y : Int(max_loop)
+    normalizer = bivariate_generalized_poisson(y, z, lambda, alpha1, alpha2, alpha3,
+        eta)
+    cumulative = compute_g_r_y_z(kernel, 0, y, z, normalizer, smax)
+    i = 0
+    while cumulative < u && i < y + z
+        i += 1
+        cumulative += compute_g_r_y_z(kernel, i, y, z, normalizer, smax)
+    end
+    return i
+end
+
+"""
+    draw_random_g(order, u, y, z, lambda, alpha1, alpha2, alpha3, alpha, eta, max_loop)
+
+Draws the autoregressive component: from `g(r | y)` for `order == 1`, from
+`g(r | y, z)` for `order == 2`.
+"""
+function draw_random_g(order, u, y, z, lambda, alpha1, alpha2, alpha3, alpha, eta,
+        max_loop)
+    if Int(order) == 1
         return draw_random_g_r_y_variable(u, y, alpha, eta, lambda)
-    elseif order == 2
-        return draw_random_g_r_y_z_variable(u, y, z, lambda, alpha1, alpha2, alpha3, eta, max)
     end
+    return draw_random_g_r_y_z_variable(u, y, z, lambda, alpha1, alpha2, alpha3, eta,
+        max_loop)
 end
 
 """
-    cocoSim(type, order, parameter, n, covariates=nothing, link="log", n_burn_in=200, x=zeros(Int(n + n_burn_in)))
+    cocoSim(type, order, parameter, n, covariates=nothing, link="log", n_burn_in=200,
+            x=zeros(Int(n + n_burn_in)))
 
-Simulates a count time series based on an integer autoregressive model. The function accommodates both first-order and second-order models, with optional covariate information via a specified link function.
-
-# Arguments
-- `type`: A string indicating the model type (e.g., `"GP"` for generalized Poisson). This parameter affects how the dispersion parameter `eta` is set.
-- `order`: An integer (1 or 2) specifying the autoregressive model order.
-- `parameter`: A vector of model parameters. For order 1 models, the first element is `alpha` and (if `type` is `"GP"`) the second is `eta`. For order 2 models, the first three elements are `alpha1`, `alpha2`, `alpha3`, and (if `type` is `"GP"`) the fourth is `eta`.
-- `n`: The number of observations to simulate after the burn-in period.
-- `covariates` (optional): A matrix of covariate values. If provided, these are used with the specified link function to compute the rate parameter `lambda`.
-- `link` (optional): A string specifying the link function to use (default is `"log"`).
-- `n_burn_in` (optional): The number of initial burn-in observations to discard (default is 200).
-- `x` (optional): An initial vector for the time series with length `n + n_burn_in`. Defaults to an integer array initialized with zeros.
-
-# Returns
-A vector of simulated count data of length `n`, corresponding to the time series after the burn-in period.
-
-# Details
-- The rate parameter `lambda` is computed using a link function (obtained via `get_link_function(link)`) applied to the covariates if provided, or is set to the last element of `parameter` otherwise.
-- Depending on the model order, the appropriate autoregressive parameters are extracted from `parameter`.
-- For each time step (starting from t = 3), the simulated count is the sum of a draw from a custom autoregressive component (via `draw_random_g`) and a draw from a generalized Poisson component (via `draw_random_generalized_poisson_variable`).
+Simulates a count time series of length `n` from a (Generalized) Poisson
+autoregressive model, discarding `n_burn_in` initial observations. Parameter
+layout: `alpha[, eta], lambda` for order 1 and
+`alpha1, alpha2, alpha3[, eta], lambda` for order 2; with covariates the
+trailing `lambda` is replaced by the regression coefficients.
 """
-function cocoSim(type, order, parameter, n, covariates=nothing,
-                 link="log", n_burn_in=200,
-                 x=zeros(Int(n + n_burn_in)))
-    
+function cocoSim(type, order, parameter, n, covariates = nothing, link = "log",
+        n_burn_in = 200, x = zeros(Int(n + n_burn_in)))
+    n = Int(n)
+    n_burn_in = Int(n_burn_in)
+    order = Int(order)
+    n_total = n + n_burn_in
     link_function = get_link_function(link)
-    
+
     if !isnothing(covariates)
-        lambda = link_function.(repeat(covariates * parameter[Int((end-(size(covariates)[2]-1))):Int(end)], Int(ceil(1 + n_burn_in / n)))[Int((end-n_burn_in-n+1)):Int(end)])
+        n_betas = size(covariates, 2)
+        lambda_data = link_function.(covariates * parameter[(end - n_betas + 1):end])
+        lambda = repeat(lambda_data, Int(ceil(1 + n_burn_in / n)))[(end - n_total + 1):end]
     else
-        lambda = repeat([last(parameter)], Int(n + n_burn_in))
+        lambda = fill(float(last(parameter)), n_total)
     end
-    
+
     if order == 2
-        alpha1 = parameter[1]
-        alpha2 = parameter[2]
-        alpha3 = parameter[3]
+        alpha1, alpha2, alpha3 = parameter[1], parameter[2], parameter[3]
         alpha = nothing
-        if type == "GP"
-            eta = parameter[4]
-        else
-            eta = 0
-        end
+        eta = type == "GP" ? parameter[4] : zero(eltype(lambda))
     else
-        alpha1 = nothing
-        alpha2 = nothing
-        alpha3 = nothing
+        alpha1 = alpha2 = alpha3 = nothing
         alpha = parameter[1]
-        if type == "GP"
-            eta = parameter[2]
-        else
-            eta = 0
-        end
+        eta = type == "GP" ? parameter[2] : zero(eltype(lambda))
     end
-    
-    for t in 3:(Int(n + n_burn_in))
-        x[t] = draw_random_g(order, rand(Uniform(0,1),1)[1], Int(x[t-1]), Int(x[t-2]), lambda[t], alpha1, alpha2, alpha3, alpha, eta, nothing) +
-               draw_random_generalized_poisson_variable(rand(Uniform(0,1),1)[1], lambda[t], eta)
+
+    for t in 3:n_total
+        x[t] = draw_random_g(order, rand(), Int(x[t - 1]), Int(x[t - 2]), lambda[t],
+            alpha1, alpha2, alpha3, alpha, eta, nothing) +
+               draw_random_generalized_poisson_variable(rand(), lambda[t], eta)
     end
-    
-    return x[Int((end-n+1)):Int(end)]
+
+    return x[(end - n + 1):end]
 end

--- a/src/Coconots.jl
+++ b/src/Coconots.jl
@@ -1,14 +1,29 @@
 module Coconots
-    include("Utils.jl")
-    include("Bounds.jl")
-    include("CocoBoot.jl")
-    include("CocoPredict.jl")
-    include("CocoReg.jl")
-    include("CocoSim.jl")
-    include("CountDistributions.jl")
-    include("Likelihood.jl")
-    include("LinkFunctions.jl")
-    include("Scores.jl")
-    include("StartingValues.jl")
-    #include("PreCompilation.jl")
+
+using LinearAlgebra: diag, inv
+using Random
+using Statistics: cor, mean, quantile!, var
+using StatsBase: autocor
+using DataFrames: DataFrame
+using FreqTables
+using SpecialFunctions: logfactorial
+using ForwardDiff
+using Optimization
+using OptimizationOptimJL
+using Optim: Fminbox, LBFGS, NelderMead
+using Base.Threads: @threads, nthreads
+
+include("Utils.jl")
+include("LinkFunctions.jl")
+include("CountDistributions.jl")
+include("Likelihood.jl")
+include("Bounds.jl")
+include("StartingValues.jl")
+include("CocoReg.jl")
+include("CocoSim.jl")
+include("CocoPredict.jl")
+include("CocoBoot.jl")
+include("Scores.jl")
+include("PreCompilation.jl")
+
 end

--- a/src/CountDistributions.jl
+++ b/src/CountDistributions.jl
@@ -1,80 +1,91 @@
+const MAX_FACTORIAL_ARGUMENT = 170
+const FACTORIAL_TABLE = Float64[factorial(big(k)) for k in 0:MAX_FACTORIAL_ARGUMENT]
+
+"""
+    float_factorial(x)
+
+Factorial of `x` as a `Float64`, read from a precomputed table. Valid for
+`0 <= x <= 170` (Float64 factorials overflow at 171).
+"""
+@inline function float_factorial(x::Integer)
+    return @inbounds FACTORIAL_TABLE[Int(x) + 1]
+end
+
+"""
+    log_generalized_poisson_pdf(x, lambda, eta)
+
+Log probability mass function of the Generalized Poisson distribution at the
+non-negative integer `x` with rate `lambda` and dispersion `eta`. Used instead
+of the direct pmf whenever factorials would overflow.
+"""
+@inline function log_generalized_poisson_pdf(x::Integer, lambda::Real, eta::Real)
+    return log(lambda) + (x - 1) * log(lambda + x * eta) - lambda - x * eta -
+           logfactorial(x)
+end
+
 """
     poisson_distribution(x, lambda)
 
-Computes the probability mass function (PMF) of the Poisson distribution at a given count `x` with parameter `λ`.
-
-# Arguments
-- `x::Integer`: Non-negative integer value at which to evaluate the PMF.
-- `lambda::Real`: Positive rate parameter of the Poisson distribution.
-
-# Returns
-- `Real`: Probability of observing the value `x`.
+Probability mass function of the Poisson distribution at count `x` with rate
+`lambda`.
 """
-function poisson_distribution(x, lambda)
-    return exp(-lambda) * lambda^x / factorial(Int(x))
+function poisson_distribution(x::Real, lambda::Real)
+    xi = Int(x)
+    if xi <= MAX_FACTORIAL_ARGUMENT
+        return exp(-lambda) * lambda^xi / float_factorial(xi)
+    end
+    return exp(xi * log(lambda) - lambda - logfactorial(xi))
 end
 
 """
     generalized_poisson_distribution(x, lambda, eta)
 
-Computes the probability mass function of the Generalized Poisson distribution.
-
-# Arguments
-- `x::Integer`: Non-negative integer value at which to evaluate the PMF.
-- `lambda::Real`: Positive rate parameter.
-- `eta::Real`: Dispersion parameter.
-
-# Returns
-- `Real`: Probability of observing the value `x`.
+Probability mass function of the Generalized Poisson distribution at count `x`
+with rate `lambda` and dispersion `eta`. Uses a factorial lookup table for
+`x <= 170` and log-space evaluation beyond, so it never allocates `BigInt`s and
+is differentiable in `lambda` and `eta`.
 """
-function generalized_poisson_distribution(x, lambda, eta)
-    if x < 20
-        return exp(-lambda - x*eta) * lambda*(lambda + x*eta)^(x - 1) / factorial(Int(x))
-    else
-        return exp(-lambda - x*eta) * lambda*(lambda + x*eta)^(x - 1) / Float64(factorial(big(Int(x))))
+@inline function generalized_poisson_distribution(x::Real, lambda::Real, eta::Real)
+    xi = Int(x)
+    if xi <= MAX_FACTORIAL_ARGUMENT
+        return exp(-lambda - xi * eta) * lambda * (lambda + xi * eta)^(xi - 1) /
+               float_factorial(xi)
     end
+    return exp(log_generalized_poisson_pdf(xi, lambda, eta))
 end
 
 """
     bivariate_generalized_poisson(y, z, lambda, alpha1, alpha2, alpha3, eta)
 
-Computes the joint probability mass function of the bivariate generalized Poisson distribution.
-
-# Arguments
-- `y::Integer`: First observed count.
-- `z::Integer`: Second observed count.
-- `lambda::Real`: Base rate parameter.
-- `alpha1::Real`: Interaction parameter.
-- `alpha2::Real`: Interaction parameter.
-- `alpha3::Real`: Interaction parameter.
-- `eta::Real`: Dispersion parameter.
-
-# Returns
-- `Real`: Joint probability of observing counts `(y, z)`.
+Joint probability mass function of the bivariate Generalized Poisson
+distribution of two consecutive counts `(y, z)`. All loop-invariant quantities
+are hoisted; factorials come from the lookup table (log-space beyond 170).
 """
-function bivariate_generalized_poisson(y, z, lambda, alpha1, alpha2, alpha3, eta)
+function bivariate_generalized_poisson(y::Real, z::Real, lambda::Real, alpha1::Real,
+        alpha2::Real, alpha3::Real, eta::Real)
+    yi, zi = Int(y), Int(z)
     U = compute_U(alpha1, alpha2, alpha3)
-    beta3 = compute_beta_i(lambda, U, alpha3)
-    beta2 = compute_beta_i(lambda, U, alpha2)
     beta1 = compute_beta_i(lambda, U, alpha1)
+    beta3 = compute_beta_i(lambda, U, alpha3)
+    c = lambda * U * (1 - alpha1 - alpha3)
+    d = lambda * U * (alpha1 + alpha3)
 
-    sum = 0.0
-    if max(y,z) >= 20
-        for j in 0:min(y,z)
-            sum += (lambda*U*(1 - alpha1 - alpha3) + eta*(y - j))^(y - j - 1) *
-                   (lambda*U*(1 - alpha1 - alpha3) + eta*(z - j))^(z - j - 1) *
-                   (lambda*U*(alpha1 + alpha3) + eta*j)^(j - 1) /
-                   Float64(factorial(big(Int(j)))) / Float64(factorial(big(Int(y - j)))) /
-                   Float64(factorial(big(Int(z - j)))) * exp(j*eta)
+    total = zero(promote_type(typeof(c), typeof(eta)))
+    if max(yi, zi) <= MAX_FACTORIAL_ARGUMENT
+        for j in 0:min(yi, zi)
+            total += (c + eta * (yi - j))^(yi - j - 1) * (c + eta * (zi - j))^(zi - j - 1) *
+                     (d + eta * j)^(j - 1) / float_factorial(j) / float_factorial(yi - j) /
+                     float_factorial(zi - j) * exp(j * eta)
         end
     else
-        for j in 0:min(y,z)
-            sum += (lambda*U*(1 - alpha1 - alpha3) + eta*(y - j))^(y - j - 1) *
-                   (lambda*U*(1 - alpha1 - alpha3) + eta*(z - j))^(z - j - 1) *
-                   (lambda*U*(alpha1 + alpha3) + eta*j)^(j - 1) /
-                   factorial(Int(j)) / factorial(Int(y - j)) / factorial(Int(z - j)) * exp(j*eta)
+        for j in 0:min(yi, zi)
+            total += exp((yi - j - 1) * log(c + eta * (yi - j)) +
+                         (zi - j - 1) * log(c + eta * (zi - j)) +
+                         (j - 1) * log(d + eta * j) - logfactorial(j) -
+                         logfactorial(yi - j) - logfactorial(zi - j) + j * eta)
         end
     end
 
-    return sum * (beta1 + beta3) * (lambda*U*(1 - alpha1 - alpha3))^2 * exp(-(beta1 + beta3) - 2*(lambda*U*(1 - alpha1 - alpha3)) - y*eta - z*eta)
+    return total * (beta1 + beta3) * c^2 *
+           exp(-(beta1 + beta3) - 2 * c - yi * eta - zi * eta)
 end

--- a/src/Likelihood.jl
+++ b/src/Likelihood.jl
@@ -1,239 +1,419 @@
 """
-    compute_distribution_convolution_x_r_y(x, y, lambda, alpha, eta)
-
-Computes the cumulative distribution for the first-order convolution likelihood.
-It sums the convolution probability mass function from 0 to `x`.
-
-# Arguments
-- `x`: The count up to which the cumulative probability is computed.
-- `y`: The lagged count (conditioning variable).
-- `lambda`: The rate parameter.
-- `alpha`: The autoregressive parameter.
-- `eta`: The dispersion parameter.
-
-# Returns
-A scalar representing the cumulative probability up to `x`. Returns 0 if `x` is negative.
-"""
-function compute_distribution_convolution_x_r_y(x, y, lambda, alpha, eta)
-    if x < 0
-        return 0
-    end
-    return sum([compute_convolution_x_r_y(i, y, lambda, alpha, eta) for i in 0:x])
-end
-
-"""
-    compute_distribution_convolution_x_r_y_z(x, y, z, alpha1, alpha2, alpha3, lambda, eta, max_loop=nothing)
-
-Computes the cumulative distribution for the second-order convolution likelihood.
-It sums the convolution probability mass function from 0 to `x`.
-
-# Arguments
-- `x`: The count up to which the cumulative probability is computed.
-- `y`: The first lagged count.
-- `z`: The second lagged count.
-- `alpha1`, `alpha2`, `alpha3`: The autoregressive parameters for the second-order model.
-- `lambda`: The rate parameter.
-- `eta`: The dispersion parameter.
-- `max_loop` (optional): An optional parameter controlling iteration limits.
-
-# Returns
-A scalar representing the cumulative probability up to `x`. Returns 0 if `x` is negative.
-"""
-function compute_distribution_convolution_x_r_y_z(x, y, z, alpha1, alpha2, alpha3, lambda, eta, max_loop=nothing)
-    if x < 0
-        return 0
-    end
-    return sum([compute_convolution_x_r_y_z(i, y, z, lambda, alpha1, alpha2, alpha3, eta, max_loop) for i in 0:x])
-end
-
-"""
-    compute_g_r_y_z(r, y, z, lambda, alpha1, alpha2, alpha3, eta, max)
-
-Computes the convolution probability mass function for a second-order model component.
-
-# Arguments
-- `r`: The target value in the convolution sum.
-- `y`: The first lagged count.
-- `z`: The second lagged count.
-- `lambda`: The rate parameter.
-- `alpha1`, `alpha2`, `alpha3`: The autoregressive parameters.
-- `eta`: The dispersion parameter.
-- `max`: The maximum summation index for the inner loops (if not provided, defaults to `y`).
-
-# Returns
-The computed probability mass value, normalized by the bivariate generalized Poisson probability.
-"""
-function compute_g_r_y_z(r, y, z, lambda, alpha1, alpha2, alpha3, eta, max)
-    U = compute_U(alpha1, alpha2, alpha3)
-    beta3 = compute_beta_i(lambda, U, alpha3)
-    beta2 = compute_beta_i(lambda, U, alpha2)
-    beta1 = compute_beta_i(lambda, U, alpha1)
-    zeta = compute_zeta(lambda, U, alpha1, alpha3)
-    
-    if isnothing(max)
-        max = y
-    end
-
-    sum = 0.0
-    for s in 0:max, v in 0:max, w in 0:max
-        if ((r - s - v) >= 0) & ((z - r + v - w) >= 0) & ((y - s - v - w) >= 0)
-            sum = sum + generalized_poisson_distribution(s, beta3, eta) *
-                        generalized_poisson_distribution(v, beta1, eta) *
-                        generalized_poisson_distribution(w, beta1, eta) *
-                        generalized_poisson_distribution(r - s - v, beta2, eta) *
-                        generalized_poisson_distribution(z - r + v - w, lambda, eta) *
-                        generalized_poisson_distribution(y - s - v - w, zeta, eta)
-        end
-    end
-
-    return sum / bivariate_generalized_poisson(y, z, lambda, alpha1, alpha2, alpha3, eta)
-end
-
-"""
     compute_g_r_y(y, r, alpha, eta, lambda)
 
-Computes the convolution probability mass function for a first-order model component using a closed-form expression.
-
-# Arguments
-- `y`: The lagged count.
-- `r`: The target value in the convolution sum.
-- `alpha`: The autoregressive parameter.
-- `eta`: The dispersion parameter.
-- `lambda`: The rate parameter.
-
-# Returns
-The computed probability mass value. For small `y`, standard factorials are used; for larger `y`, big integer factorials are applied.
+Convolution probability mass `g(r | y)` of the first-order model (closed
+form). Uses the factorial lookup table for `y <= 170` and log-space
+evaluation beyond, so no `BigInt`s are ever allocated.
 """
-function compute_g_r_y(y, r, alpha, eta, lambda)
+function compute_g_r_y(y::Real, r::Real, alpha::Real, eta::Real, lambda::Real)
+    yi, ri = Int(y), Int(r)
     psi = eta * (1 - alpha) / lambda
-    if y < 20
-        return factorial(Int(y)) / factorial(Int(r)) / factorial(Int(y - r)) * alpha * (1 - alpha) *
-               (alpha + psi * r)^(r - 1) * (1 - alpha + psi * (y - r))^(y - r - 1) /
-               (1 + psi * y)^(y - 1)
-    else
-        return Float64(factorial(big(Int(y)))) / Float64(factorial(big(Int(r)))) /
-               Float64(factorial(big(Int(y - r)))) * alpha * (1 - alpha) *
-               (alpha + psi * r)^(r - 1) * (1 - alpha + psi * (y - r))^(y - r - 1) /
-               (1 + psi * y)^(y - 1)
+    if yi <= MAX_FACTORIAL_ARGUMENT
+        return float_factorial(yi) / float_factorial(ri) / float_factorial(yi - ri) *
+               alpha * (1 - alpha) * (alpha + psi * ri)^(ri - 1) *
+               (1 - alpha + psi * (yi - ri))^(yi - ri - 1) / (1 + psi * yi)^(yi - 1)
     end
+    return exp(logfactorial(yi) - logfactorial(ri) - logfactorial(yi - ri) + log(alpha) +
+               log(1 - alpha) + (ri - 1) * log(alpha + psi * ri) +
+               (yi - ri - 1) * log(1 - alpha + psi * (yi - ri)) -
+               (yi - 1) * log(1 + psi * yi))
 end
 
 """
     compute_convolution_x_r_y(x, y, lambda, alpha, eta)
 
-Computes the convolution likelihood for a first-order model by summing contributions over possible latent counts.
-
-# Arguments
-- `x`: The observed count.
-- `y`: The lagged count.
-- `lambda`: The rate parameter.
-- `alpha`: The autoregressive parameter.
-- `eta`: The dispersion parameter.
-
-# Returns
-The sum of the convolution probability over `r` from 0 to `min(x, y)`.
+Transition probability `P(x | y)` of the first-order model: the convolution of
+`g(r | y)` with the Generalized Poisson innovation, summed over
+`r = 0, ..., min(x, y)`.
 """
-function compute_convolution_x_r_y(x, y, lambda, alpha, eta)
-    sum = 0.0
-    for r in 0:min(x, y)
-        if y >= r
-            sum = sum + compute_g_r_y(y, r, alpha, eta, lambda) * generalized_poisson_distribution(x - r, lambda, eta)
+function compute_convolution_x_r_y(x::Real, y::Real, lambda::Real, alpha::Real, eta::Real)
+    xi, yi = Int(x), Int(y)
+    total = zero(promote_type(typeof(lambda), typeof(alpha), typeof(eta)))
+    for r in 0:min(xi, yi)
+        total += compute_g_r_y(yi, r, alpha, eta, lambda) *
+                 generalized_poisson_distribution(xi - r, lambda, eta)
+    end
+    return total
+end
+
+"""
+    convolution_pmf_vector(xmax, y, lambda, alpha, eta)
+
+Vector of first-order transition probabilities `P(x | y)` for
+`x = 0, ..., xmax`, computed in one pass: `g(r | y)` and the innovation pmf are
+tabulated once and reused across all `x` (instead of recomputing them for every
+cumulative-distribution evaluation).
+"""
+function convolution_pmf_vector(xmax::Integer, y::Integer, lambda::Real, alpha::Real,
+        eta::Real)
+    T = promote_type(typeof(lambda), typeof(alpha), typeof(eta))
+    rmax = min(xmax, y)
+    g = T[compute_g_r_y(y, r, alpha, eta, lambda) for r in 0:rmax]
+    innovation = T[generalized_poisson_distribution(i, lambda, eta) for i in 0:xmax]
+    pmf = Vector{T}(undef, xmax + 1)
+    @inbounds for x in 0:xmax
+        total = zero(T)
+        for r in 0:min(x, rmax)
+            total += g[r + 1] * innovation[x - r + 1]
+        end
+        pmf[x + 1] = total
+    end
+    return pmf
+end
+
+"""
+    compute_distribution_convolution_x_r_y(x, y, lambda, alpha, eta)
+
+Cumulative distribution of the first-order transition probability, summed from
+0 to `x`. Returns 0 for negative `x`.
+"""
+function compute_distribution_convolution_x_r_y(x::Real, y::Real, lambda::Real,
+        alpha::Real, eta::Real)
+    T = promote_type(typeof(lambda), typeof(alpha), typeof(eta))
+    x < 0 && return zero(T)
+    return sum(convolution_pmf_vector(Int(x), Int(y), lambda, alpha, eta))
+end
+
+#--------------------------------------------------------------------------------------
+# Second-order kernel
+#--------------------------------------------------------------------------------------
+
+"""
+    GP2Kernel(lambda, alpha1, alpha2, alpha3, eta, max_index)
+
+Precomputed state for second-order convolution evaluations at fixed parameter
+values: the derived rates (`beta1`, `beta2`, `beta3`, `zeta`) and Generalized
+Poisson pmf lookup tables for each of them on `0:max_index`. Building the
+kernel once and reusing it across observations removes the dominant redundant
+work of the second-order likelihood.
+"""
+struct GP2Kernel{T <: Real}
+    lambda::T
+    alpha1::T
+    alpha2::T
+    alpha3::T
+    eta::T
+    gp_beta1::Vector{T}
+    gp_beta2::Vector{T}
+    gp_beta3::Vector{T}
+    gp_lambda::Vector{T}
+    gp_zeta::Vector{T}
+end
+
+function GP2Kernel(lambda::Real, alpha1::Real, alpha2::Real, alpha3::Real, eta::Real,
+        max_index::Integer)
+    U = compute_U(alpha1, alpha2, alpha3)
+    beta1 = compute_beta_i(lambda, U, alpha1)
+    beta2 = compute_beta_i(lambda, U, alpha2)
+    beta3 = compute_beta_i(lambda, U, alpha3)
+    zeta = compute_zeta(lambda, U, alpha1, alpha3)
+    T = promote_type(typeof(beta1), typeof(eta))
+    table(rate) = T[generalized_poisson_distribution(i, rate, eta) for i in 0:max_index]
+    return GP2Kernel{T}(lambda, alpha1, alpha2, alpha3, eta, table(beta1), table(beta2),
+        table(beta3), table(lambda), table(zeta))
+end
+
+"""
+    compute_g_r_y_z(kernel, r, y, z, normalizer, smax)
+
+Convolution probability mass `g(r | y, z)` of the second-order model, using
+the kernel's pmf tables. The triple sum runs only over the feasible set
+(`r - s - v >= 0`, `z - r + v - w >= 0`, `y - s - v - w >= 0` intersected with
+`s, v, w <= smax`) instead of a guarded full cube. `normalizer` is the
+bivariate Generalized Poisson mass of `(y, z)`, computed once by the caller
+and hoisted out of any loop over `r`.
+"""
+function compute_g_r_y_z(kernel::GP2Kernel{T}, r::Integer, y::Integer, z::Integer,
+        normalizer::Real, smax::Integer) where {T}
+    total = zero(T)
+    @inbounds for s in 0:min(smax, r, y)
+        ps = kernel.gp_beta3[s + 1]
+        for v in 0:min(smax, r - s, y - s)
+            pv = ps * kernel.gp_beta1[v + 1] * kernel.gp_beta2[r - s - v + 1]
+            zrv = z - r + v
+            ysv = y - s - v
+            for w in 0:min(smax, ysv, zrv)
+                total += pv * kernel.gp_beta1[w + 1] * kernel.gp_lambda[zrv - w + 1] *
+                         kernel.gp_zeta[ysv - w + 1]
+            end
         end
     end
-    return sum
+    return total / normalizer
+end
+
+function _check_kernel_size(kernel::GP2Kernel, required_index::Integer)
+    length(kernel.gp_lambda) > required_index || throw(ArgumentError(
+        "GP2Kernel tables cover 0:$(length(kernel.gp_lambda) - 1) but index " *
+        "$required_index is required; construct the kernel with a larger max_index"))
+    return nothing
+end
+
+function convolution_x_r_y_z(kernel::GP2Kernel{T}, x::Integer, y::Integer, z::Integer,
+        max_loop) where {T}
+    _check_kernel_size(kernel, max(x, y + z))
+    smax = max_loop === nothing ? y : Int(max_loop)
+    normalizer = bivariate_generalized_poisson(y, z, kernel.lambda, kernel.alpha1,
+        kernel.alpha2, kernel.alpha3, kernel.eta)
+    total = zero(T)
+    @inbounds for r in 0:min(x, y + z)
+        total += compute_g_r_y_z(kernel, r, y, z, normalizer, smax) *
+                 kernel.gp_lambda[x - r + 1]
+    end
+    return total
 end
 
 """
-    compute_negative_log_likelihood_GP1(lambdas, alpha, eta, data, array_fill=Array{Union{Float64, ForwardDiff.Dual}}(undef, length(data) - 1))
+    convolution_pmf_vector(kernel, xmax, y, z, max_loop)
 
-Computes the negative log-likelihood for a first-order generalized Poisson model via convolution likelihood.
-
-# Arguments
-- `lambdas`: A vector of rate parameters corresponding to each observation.
-- `alpha`: The autoregressive parameter.
-- `eta`: The dispersion parameter.
-- `data`: A vector of observed counts.
-- `array_fill` (optional): Preallocated array for storing individual negative log-likelihood values.
-
-# Returns
-The total negative log-likelihood computed as the sum of the log-likelihood contributions for each observation (from the second observation onward).
+Vector of second-order transition probabilities `P(x | y, z)` for
+`x = 0, ..., xmax`. The `g(r | y, z)` values are computed once and reused for
+every `x`, turning the previously quadratic cumulative-distribution work into a
+single linear convolution pass.
 """
-function compute_negative_log_likelihood_GP1(lambdas, alpha, eta, data, array_fill=Array{Union{Float64, ForwardDiff.Dual}}(undef, length(data) - 1))
-    Threads.@threads for t in eachindex(data)[2:end]
-        array_fill[t - 1] = -log(compute_convolution_x_r_y(data[t], data[t - 1], lambdas[t], alpha, eta))
+function convolution_pmf_vector(kernel::GP2Kernel{T}, xmax::Integer, y::Integer,
+        z::Integer, max_loop) where {T}
+    _check_kernel_size(kernel, max(xmax, y + z))
+    smax = max_loop === nothing ? y : Int(max_loop)
+    normalizer = bivariate_generalized_poisson(y, z, kernel.lambda, kernel.alpha1,
+        kernel.alpha2, kernel.alpha3, kernel.eta)
+    rmax = min(xmax, y + z)
+    g = T[compute_g_r_y_z(kernel, r, y, z, normalizer, smax) for r in 0:rmax]
+    pmf = Vector{T}(undef, xmax + 1)
+    @inbounds for x in 0:xmax
+        total = zero(T)
+        for r in 0:min(x, rmax)
+            total += g[r + 1] * kernel.gp_lambda[x - r + 1]
+        end
+        pmf[x + 1] = total
     end
-    return sum(array_fill)
+    return pmf
+end
+
+#--------------------------------------------------------------------------------------
+# Second-order public entry points (kept API-compatible with earlier versions)
+#--------------------------------------------------------------------------------------
+
+"""
+    compute_g_r_y_z(r, y, z, lambda, alpha1, alpha2, alpha3, eta, max_loop=nothing)
+
+Convolution probability mass `g(r | y, z)` of the second-order model. Builds a
+one-shot [`GP2Kernel`](@ref); prefer constructing the kernel once when
+evaluating many `(r, y, z)` combinations at fixed parameters.
+"""
+function compute_g_r_y_z(r::Real, y::Real, z::Real, lambda::Real, alpha1::Real,
+        alpha2::Real, alpha3::Real, eta::Real, max_loop = nothing)
+    ri, yi, zi = Int(r), Int(y), Int(z)
+    kernel = GP2Kernel(lambda, alpha1, alpha2, alpha3, eta, max(ri, yi + zi))
+    smax = max_loop === nothing ? yi : Int(max_loop)
+    normalizer = bivariate_generalized_poisson(yi, zi, lambda, alpha1, alpha2, alpha3,
+        eta)
+    return compute_g_r_y_z(kernel, ri, yi, zi, normalizer, smax)
 end
 
 """
-    compute_negative_log_likelihood_GP2(lambdas, alpha1, alpha2, alpha3, eta, data, max=nothing, array_fill=Array{Union{Float64, ForwardDiff.Dual}}(undef, length(data) - 2))
+    compute_convolution_x_r_y_z(x, y, z, lambda, alpha1, alpha2, alpha3, eta, max_loop=nothing)
 
-Computes the negative log-likelihood for a second-order generalized Poisson model via convolution likelihood.
-
-# Arguments
-- `lambdas`: A vector of rate parameters for each observation.
-- `alpha1`, `alpha2`, `alpha3`: The autoregressive parameters.
-- `eta`: The dispersion parameter.
-- `data`: A vector of observed counts.
-- `max` (optional): A parameter to control iteration limits in the convolution calculation.
-- `array_fill` (optional): Preallocated array for storing individual negative log-likelihood values.
-
-# Returns
-The total negative log-likelihood computed as the sum of the log-likelihood contributions for each observation (from the third observation onward).
+Transition probability `P(x | y, z)` of the second-order model.
 """
-function compute_negative_log_likelihood_GP2(lambdas, alpha1, alpha2, alpha3, eta, data, max=nothing, array_fill=Array{Union{Float64, ForwardDiff.Dual}}(undef, length(data) - 2))
-    Threads.@threads for t in eachindex(data)[3:end]
-        array_fill[t - 2] = -log(compute_convolution_x_r_y_z(data[t], data[t - 1], data[t - 2], lambdas[t], alpha1, alpha2, alpha3, eta, max))
-    end
-    return sum(array_fill)
+function compute_convolution_x_r_y_z(x::Real, y::Real, z::Real, lambda::Real,
+        alpha1::Real, alpha2::Real, alpha3::Real, eta::Real, max_loop = nothing)
+    xi, yi, zi = Int(x), Int(y), Int(z)
+    kernel = GP2Kernel(lambda, alpha1, alpha2, alpha3, eta, max(xi, yi + zi))
+    return convolution_x_r_y_z(kernel, xi, yi, zi, max_loop)
 end
 
 """
-    compute_convolution_x_r_y_z(x, y, z, lambda, alpha1, alpha2, alpha3, eta, max=nothing)
+    compute_distribution_convolution_x_r_y_z(x, y, z, alpha1, alpha2, alpha3, lambda, eta, max_loop=nothing)
 
-Computes the convolution likelihood for a second-order model by summing contributions over latent counts.
-
-# Arguments
-- `x`: The observed count.
-- `y`: The first lagged count.
-- `z`: The second lagged count.
-- `lambda`: The rate parameter.
-- `alpha1`, `alpha2`, `alpha3`: The autoregressive parameters.
-- `eta`: The dispersion parameter.
-- `max` (optional): An optional parameter controlling the maximum iteration in the convolution sum.
-
-# Returns
-The summed convolution probability value.
+Cumulative distribution of the second-order transition probability, summed
+from 0 to `x`. Returns 0 for negative `x`. (Note the historical argument
+order: the alphas precede `lambda` here.)
 """
-function compute_convolution_x_r_y_z(x, y, z, lambda, alpha1, alpha2, alpha3, eta, max=nothing)
-    sum = 0.0
-    for r in 0:min(x, y + z)
-        sum = sum + compute_g_r_y_z(r, y, z, lambda, alpha1, alpha2, alpha3, eta, max) * generalized_poisson_distribution(x - r, lambda, eta)
+function compute_distribution_convolution_x_r_y_z(x::Real, y::Real, z::Real,
+        alpha1::Real, alpha2::Real, alpha3::Real, lambda::Real, eta::Real,
+        max_loop = nothing)
+    T = promote_type(typeof(lambda), typeof(alpha1), typeof(eta))
+    x < 0 && return zero(T)
+    xi, yi, zi = Int(x), Int(y), Int(z)
+    kernel = GP2Kernel(lambda, alpha1, alpha2, alpha3, eta, max(xi, yi + zi))
+    return sum(convolution_pmf_vector(kernel, xi, yi, zi, max_loop))
+end
+
+#--------------------------------------------------------------------------------------
+# Negative log-likelihoods
+#--------------------------------------------------------------------------------------
+
+function _transition_counts(data::AbstractVector, order::Integer)
+    if Int(order) == 1
+        counts = Dict{NTuple{2, Int}, Int}()
+        for t in 2:length(data)
+            key = (Int(data[t]), Int(data[t - 1]))
+            counts[key] = get(counts, key, 0) + 1
+        end
+    else
+        counts = Dict{NTuple{3, Int}, Int}()
+        for t in 3:length(data)
+            key = (Int(data[t]), Int(data[t - 1]), Int(data[t - 2]))
+            counts[key] = get(counts, key, 0) + 1
+        end
     end
-    return sum
+    transitions = sort!(collect(keys(counts)))
+    return transitions, Int[counts[k] for k in transitions]
+end
+
+function _nll_gp1_transitions(lambda::Real, alpha::Real, eta::Real,
+        transitions::Vector{NTuple{2, Int}}, counts::Vector{Int})
+    T = promote_type(typeof(lambda), typeof(alpha), typeof(eta))
+    if nthreads() > 1 && length(transitions) > 32
+        parts = Vector{T}(undef, length(transitions))
+        @threads for i in eachindex(transitions)
+            x, y = transitions[i]
+            parts[i] = -counts[i] * log(compute_convolution_x_r_y(x, y, lambda, alpha,
+                eta))
+        end
+        return sum(parts)
+    end
+    total = zero(T)
+    for i in eachindex(transitions)
+        x, y = transitions[i]
+        total -= counts[i] * log(compute_convolution_x_r_y(x, y, lambda, alpha, eta))
+    end
+    return total
+end
+
+function _nll_gp2_transitions(lambda::Real, alpha1::Real, alpha2::Real, alpha3::Real,
+        eta::Real, transitions::Vector{NTuple{3, Int}}, counts::Vector{Int},
+        max_index::Integer, max_loop)
+    kernel = GP2Kernel(lambda, alpha1, alpha2, alpha3, eta, max_index)
+    T = eltype(kernel.gp_lambda)
+    if nthreads() > 1 && length(transitions) > 32
+        parts = Vector{T}(undef, length(transitions))
+        @threads for i in eachindex(transitions)
+            x, y, z = transitions[i]
+            parts[i] = -counts[i] * log(convolution_x_r_y_z(kernel, x, y, z, max_loop))
+        end
+        return sum(parts)
+    end
+    total = zero(T)
+    for i in eachindex(transitions)
+        x, y, z = transitions[i]
+        total -= counts[i] * log(convolution_x_r_y_z(kernel, x, y, z, max_loop))
+    end
+    return total
+end
+
+function _gp2_max_index(transitions::Vector{NTuple{3, Int}})
+    maximum(t -> max(t[1], t[2] + t[3]), transitions)
+end
+
+"""
+    compute_negative_log_likelihood_GP1(lambda, alpha, eta, data)
+
+Negative log-likelihood of the first-order model at a constant innovation rate
+`lambda`. Aggregates over the unique `(x_t, x_{t-1})` transitions of `data`
+(with multiplicities), so each distinct transition probability is evaluated
+exactly once.
+"""
+function compute_negative_log_likelihood_GP1(lambda::Real, alpha::Real, eta::Real,
+        data::AbstractVector)
+    transitions, counts = _transition_counts(data, 1)
+    return _nll_gp1_transitions(lambda, alpha, eta, transitions, counts)
+end
+
+"""
+    compute_negative_log_likelihood_GP1(lambdas, alpha, eta, data)
+
+Negative log-likelihood of the first-order model with an observation-specific
+innovation-rate vector `lambdas` (covariate models). Falls back to the
+constant-rate fast path when all rates coincide.
+"""
+function compute_negative_log_likelihood_GP1(lambdas::AbstractVector, alpha::Real,
+        eta::Real, data::AbstractVector)
+    allequal(lambdas) &&
+        return compute_negative_log_likelihood_GP1(first(lambdas), alpha, eta, data)
+    T = promote_type(eltype(lambdas), typeof(alpha), typeof(eta))
+    n = length(data)
+    if nthreads() > 1
+        parts = Vector{T}(undef, n - 1)
+        @threads for t in 2:n
+            parts[t - 1] = -log(compute_convolution_x_r_y(data[t], data[t - 1],
+                lambdas[t], alpha, eta))
+        end
+        return sum(parts)
+    end
+    total = zero(T)
+    for t in 2:n
+        total -= log(compute_convolution_x_r_y(data[t], data[t - 1], lambdas[t], alpha,
+            eta))
+    end
+    return total
+end
+
+function _gp2_nll_term(lambda::Real, alpha1::Real, alpha2::Real, alpha3::Real,
+        eta::Real, x::Integer, y::Integer, z::Integer, max_loop)
+    kernel = GP2Kernel(lambda, alpha1, alpha2, alpha3, eta, max(x, y + z))
+    return -log(convolution_x_r_y_z(kernel, x, y, z, max_loop))
+end
+
+"""
+    compute_negative_log_likelihood_GP2(lambda, alpha1, alpha2, alpha3, eta, data, max_loop=nothing)
+
+Negative log-likelihood of the second-order model at a constant innovation
+rate `lambda`. Builds one [`GP2Kernel`](@ref) and aggregates over the unique
+`(x_t, x_{t-1}, x_{t-2})` transitions of `data` with multiplicities.
+"""
+function compute_negative_log_likelihood_GP2(lambda::Real, alpha1::Real, alpha2::Real,
+        alpha3::Real, eta::Real, data::AbstractVector, max_loop = nothing)
+    transitions, counts = _transition_counts(data, 2)
+    return _nll_gp2_transitions(lambda, alpha1, alpha2, alpha3, eta, transitions,
+        counts, _gp2_max_index(transitions), max_loop)
+end
+
+"""
+    compute_negative_log_likelihood_GP2(lambdas, alpha1, alpha2, alpha3, eta, data, max_loop=nothing)
+
+Negative log-likelihood of the second-order model with an
+observation-specific innovation-rate vector `lambdas` (covariate models).
+Falls back to the constant-rate fast path when all rates coincide.
+"""
+function compute_negative_log_likelihood_GP2(lambdas::AbstractVector, alpha1::Real,
+        alpha2::Real, alpha3::Real, eta::Real, data::AbstractVector, max_loop = nothing)
+    allequal(lambdas) &&
+        return compute_negative_log_likelihood_GP2(first(lambdas), alpha1, alpha2,
+            alpha3, eta, data, max_loop)
+    T = promote_type(eltype(lambdas), typeof(alpha1), typeof(eta))
+    n = length(data)
+    if nthreads() > 1
+        parts = Vector{T}(undef, n - 2)
+        @threads for t in 3:n
+            parts[t - 2] = _gp2_nll_term(lambdas[t], alpha1, alpha2, alpha3, eta,
+                Int(data[t]), Int(data[t - 1]), Int(data[t - 2]), max_loop)
+        end
+        return sum(parts)
+    end
+    total = zero(T)
+    for t in 3:n
+        total += _gp2_nll_term(lambdas[t], alpha1, alpha2, alpha3, eta, Int(data[t]),
+            Int(data[t - 1]), Int(data[t - 2]), max_loop)
+    end
+    return total
 end
 
 """
     get_lambda(cocoReg_fit, last_val=false)
 
-Extracts or computes the rate parameter `lambda` from a fitted count regression model.
-
-# Arguments
-- `cocoReg_fit`: A dictionary containing the model fit details. Expected keys include `"link"`, `"covariates"`, and `"parameter"`.
-- `last_val` (optional): A boolean indicating whether to compute `lambda` using only the last row of covariates (default is `false`).
-
-# Returns
-The computed rate parameter(s) after applying the specified link function.
+Extracts or computes the innovation rate(s) `lambda` from a fitted model
+dictionary. With covariates, applies the link function to the linear
+predictor; `last_val=true` uses only the last covariate row.
 """
-function get_lambda(cocoReg_fit, last_val=false)
+function get_lambda(cocoReg_fit, last_val = false)
     link_function = get_link_function(cocoReg_fit["link"])
-    if isnothing(cocoReg_fit["covariates"])
-        return last(cocoReg_fit["parameter"])
-    else
-        if last_val
-            return link_function.(sum(cocoReg_fit["covariates"][end, :] .* cocoReg_fit["parameter"][(end - size(cocoReg_fit["covariates"])[2] + 1):end]))
-        else
-            return link_function.(cocoReg_fit["covariates"] * cocoReg_fit["parameter"][(end - size(cocoReg_fit["covariates"])[2] + 1):end])
-        end
+    covariates = cocoReg_fit["covariates"]
+    parameter = cocoReg_fit["parameter"]
+    isnothing(covariates) && return last(parameter)
+    betas = parameter[(end - size(covariates, 2) + 1):end]
+    if last_val
+        return link_function(sum(covariates[end, :] .* betas))
     end
+    return link_function.(covariates * betas)
 end

--- a/src/Likelihood.jl
+++ b/src/Likelihood.jl
@@ -53,7 +53,7 @@ function convolution_pmf_vector(xmax::Integer, y::Integer, lambda::Real, alpha::
     pmf = Vector{T}(undef, xmax + 1)
     @inbounds for x in 0:xmax
         total = zero(T)
-        for r in 0:min(x, rmax)
+        @simd for r in 0:min(x, rmax)
             total += g[r + 1] * innovation[x - r + 1]
         end
         pmf[x + 1] = total
@@ -181,7 +181,7 @@ function convolution_pmf_vector(kernel::GP2Kernel{T}, xmax::Integer, y::Integer,
     pmf = Vector{T}(undef, xmax + 1)
     @inbounds for x in 0:xmax
         total = zero(T)
-        for r in 0:min(x, rmax)
+        @simd for r in 0:min(x, rmax)
             total += g[r + 1] * kernel.gp_lambda[x - r + 1]
         end
         pmf[x + 1] = total
@@ -243,19 +243,21 @@ end
 # Negative log-likelihoods
 #--------------------------------------------------------------------------------------
 
-function _transition_counts(data::AbstractVector, order::Integer)
-    if Int(order) == 1
-        counts = Dict{NTuple{2, Int}, Int}()
-        for t in 2:length(data)
-            key = (Int(data[t]), Int(data[t - 1]))
-            counts[key] = get(counts, key, 0) + 1
-        end
-    else
-        counts = Dict{NTuple{3, Int}, Int}()
-        for t in 3:length(data)
-            key = (Int(data[t]), Int(data[t - 1]), Int(data[t - 2]))
-            counts[key] = get(counts, key, 0) + 1
-        end
+function _transition_pair_counts(data::AbstractVector)
+    counts = Dict{NTuple{2, Int}, Int}()
+    for t in 2:length(data)
+        key = (Int(data[t]), Int(data[t - 1]))
+        counts[key] = get(counts, key, 0) + 1
+    end
+    transitions = sort!(collect(keys(counts)))
+    return transitions, Int[counts[k] for k in transitions]
+end
+
+function _transition_triple_counts(data::AbstractVector)
+    counts = Dict{NTuple{3, Int}, Int}()
+    for t in 3:length(data)
+        key = (Int(data[t]), Int(data[t - 1]), Int(data[t - 2]))
+        counts[key] = get(counts, key, 0) + 1
     end
     transitions = sort!(collect(keys(counts)))
     return transitions, Int[counts[k] for k in transitions]
@@ -281,23 +283,76 @@ function _nll_gp1_transitions(lambda::Real, alpha::Real, eta::Real,
     return total
 end
 
+"""
+    _GP2TransitionGroup
+
+Unique transitions of one `(y, z)` history: the observed next counts `xs`
+with multiplicities `counts`, and the largest convolution index `rmax`
+any of them needs. Grouping lets one `g(r | y, z)` vector (and one bivariate
+normalizer) serve every `x` that shares the history.
+"""
+struct _GP2TransitionGroup
+    y::Int
+    z::Int
+    rmax::Int
+    xs::Vector{Int}
+    counts::Vector{Int}
+end
+
+function _group_transitions(transitions::Vector{NTuple{3, Int}}, counts::Vector{Int})
+    order = sortperm(transitions; by = t -> (t[2], t[3], t[1]))
+    groups = Vector{_GP2TransitionGroup}()
+    for i in order
+        x, y, z = transitions[i]
+        rmax = min(x, y + z)
+        if isempty(groups) || last(groups).y != y || last(groups).z != z
+            push!(groups, _GP2TransitionGroup(y, z, rmax, [x], [counts[i]]))
+        else
+            group = last(groups)
+            push!(group.xs, x)
+            push!(group.counts, counts[i])
+            groups[end] = _GP2TransitionGroup(y, z, max(group.rmax, rmax), group.xs,
+                group.counts)
+        end
+    end
+    return groups
+end
+
+function _nll_gp2_group(kernel::GP2Kernel{T}, group::_GP2TransitionGroup, max_loop,
+        g_buffer::Vector{T} = Vector{T}(undef, group.rmax + 1)) where {T}
+    smax = max_loop === nothing ? group.y : Int(max_loop)
+    normalizer = bivariate_generalized_poisson(group.y, group.z, kernel.lambda,
+        kernel.alpha1, kernel.alpha2, kernel.alpha3, kernel.eta)
+    @inbounds for r in 0:(group.rmax)
+        g_buffer[r + 1] = compute_g_r_y_z(kernel, r, group.y, group.z, normalizer,
+            smax)
+    end
+    total = zero(T)
+    @inbounds for (x, count) in zip(group.xs, group.counts)
+        convolution = zero(T)
+        for r in 0:min(x, group.rmax)
+            convolution += g_buffer[r + 1] * kernel.gp_lambda[x - r + 1]
+        end
+        total -= count * log(convolution)
+    end
+    return total
+end
+
 function _nll_gp2_transitions(lambda::Real, alpha1::Real, alpha2::Real, alpha3::Real,
-        eta::Real, transitions::Vector{NTuple{3, Int}}, counts::Vector{Int},
-        max_index::Integer, max_loop)
+        eta::Real, groups::Vector{_GP2TransitionGroup}, max_index::Integer, max_loop)
     kernel = GP2Kernel(lambda, alpha1, alpha2, alpha3, eta, max_index)
     T = eltype(kernel.gp_lambda)
-    if nthreads() > 1 && length(transitions) > 32
-        parts = Vector{T}(undef, length(transitions))
-        @threads for i in eachindex(transitions)
-            x, y, z = transitions[i]
-            parts[i] = -counts[i] * log(convolution_x_r_y_z(kernel, x, y, z, max_loop))
+    if nthreads() > 1 && length(groups) > 16
+        parts = Vector{T}(undef, length(groups))
+        @threads for i in eachindex(groups)
+            parts[i] = _nll_gp2_group(kernel, groups[i], max_loop)
         end
         return sum(parts)
     end
     total = zero(T)
-    for i in eachindex(transitions)
-        x, y, z = transitions[i]
-        total -= counts[i] * log(convolution_x_r_y_z(kernel, x, y, z, max_loop))
+    g_buffer = Vector{T}(undef, maximum(group -> group.rmax, groups) + 1)
+    for group in groups
+        total += _nll_gp2_group(kernel, group, max_loop, g_buffer)
     end
     return total
 end
@@ -316,7 +371,7 @@ exactly once.
 """
 function compute_negative_log_likelihood_GP1(lambda::Real, alpha::Real, eta::Real,
         data::AbstractVector)
-    transitions, counts = _transition_counts(data, 1)
+    transitions, counts = _transition_pair_counts(data)
     return _nll_gp1_transitions(lambda, alpha, eta, transitions, counts)
 end
 
@@ -364,9 +419,9 @@ rate `lambda`. Builds one [`GP2Kernel`](@ref) and aggregates over the unique
 """
 function compute_negative_log_likelihood_GP2(lambda::Real, alpha1::Real, alpha2::Real,
         alpha3::Real, eta::Real, data::AbstractVector, max_loop = nothing)
-    transitions, counts = _transition_counts(data, 2)
-    return _nll_gp2_transitions(lambda, alpha1, alpha2, alpha3, eta, transitions,
-        counts, _gp2_max_index(transitions), max_loop)
+    transitions, counts = _transition_triple_counts(data)
+    return _nll_gp2_transitions(lambda, alpha1, alpha2, alpha3, eta,
+        _group_transitions(transitions, counts), _gp2_max_index(transitions), max_loop)
 end
 
 """

--- a/src/LinkFunctions.jl
+++ b/src/LinkFunctions.jl
@@ -1,105 +1,34 @@
 """
-    exponential_function(x)
-
-Applies the exponential function element-wise. Commonly used as a link function in integer autoregressive models.
-
-# Arguments
-- `x::Real or AbstractArray`: Input value(s) for which the exponential should be computed.
-
-# Returns
-- `Real or AbstractArray`: Exponential of input.nential_function(1.0) # returns exp(1.0)
-```
-"""
-function exponential_function(x)
-    return exp(x)
-end
-
-"""
-    logistic_function(x)
-
-Computes the logistic function (sigmoid) element-wise.
-
-# Arguments
-- `x::Real or AbstractArray`: Value(s) at which the logistic function should be evaluated.
-
-# Returns
-- `Real or AbstractArray`: Logistic function evaluated at input(s).
-"""
-function logistic_function(x)
-    return 1 / (1 + exp(-x))
-end
-
-"""
     relu(x)
 
-Computes a Rectified Linear Unit (ReLU) function, modified to avoid zero values by setting a lower bound at `1e-10`.
-
-# Arguments
-- `x::Real`: Input value.
-
-# Returns
-- `Real`: max(x, 1e-10).
+Rectified linear unit with a small positive floor: `max(x, 1e-10)`.
 """
-function relu(x::Real)
-    return max(x, 1e-10)
-end
+relu(x::Real) = max(x, 1e-10)
 
 """
     softplus(x)
 
-Computes the softplus function: log(1 + exp(x)). Always positive and smooth everywhere,
-making it a differentiable alternative to relu.
-
-# Arguments
-- `x::Real`: Input value.
-
-# Returns
-- `Real`: log(1 + exp(x)).
+Numerically stable softplus `log(1 + exp(x))`; always positive and smooth.
 """
-function softplus(x::Real)
-    return x > 0 ? x + log(1 + exp(-x)) : log(1 + exp(x))
-end
+softplus(x::Real) = x > 0 ? x + log1p(exp(-x)) : log1p(exp(x))
 
 """
     identity_func(x)
 
-Identity function that returns the input unchanged.
-
-# Arguments
-- `x`: Any input value or type.
-
-# Returns
-- `Same type as input`: The input unchanged.
+Identity function.
 """
-function identity_func(x)
-    return x
-end
+identity_func(x) = x
 
 """
     get_link_function(link_function)
 
-Retrieves the appropriate link function based on the provided string identifier.
-
-# Arguments
-- `link_function::String`: Name of the link function. Allowed values are:
-    - `"log"`: Exponential function (`exp`).
-    - `"identity"`: Identity function.
-    - `"relu"`: Rectified Linear Unit (ReLU).
-    - `"softplus"`: Softplus function log(1 + exp(x)), always positive and smooth.
-
-# Returns
-- `Function`: Corresponding link function.
+Link function for the innovation rate. Allowed names: `"log"` (returns
+`exp`), `"identity"`, `"relu"` and `"softplus"`.
 """
-function get_link_function(link_function::String)
-    if link_function == "log"
-        return exp
-    elseif link_function == "identity"
-        return identity_func
-    elseif link_function == "relu"
-        return relu
-    elseif link_function == "softplus"
-        return softplus
-    else
-        error("Unknown link function")
-    end
+function get_link_function(link_function::AbstractString)
+    link_function == "log" && return exp
+    link_function == "identity" && return identity_func
+    link_function == "relu" && return relu
+    link_function == "softplus" && return softplus
+    error("Unknown link function: $link_function")
 end

--- a/src/PreCompilation.jl
+++ b/src/PreCompilation.jl
@@ -1,72 +1,24 @@
-using Random, PrecompileTools
-using Base.Iterators: product
-
+using PrecompileTools: @compile_workload
 
 @compile_workload begin
-    types = ["Poisson", "GP"]
-    orders = [1, 2]
-    links = ["identity", "log", "relu"]
-    covariates = [false, true]
-    lambdas = [0.7]
-    n = 40
+    Random.seed!(1)
+    let
+        data1 = cocoSim("Poisson", 1, [0.3, 1.0], 60, nothing, "log", 20)
+        fit1 = cocoReg("Poisson", 1, data1)
+        compute_scores(fit1, 10)
+        cocoPit(fit1, 5)
+        cocoBoot(fit1, [1:1:5;], 4)
+        cocoPredictOneStep(fit1, 0:5)
+        cocoPredictKsteps(fit1, 2, 10)
 
-    #------------------------------------------No Covariates-----------------------------------------------------------------------
-    parameter_1 = [0.3]
-    parameter_2 = [0.3, 0.05, 0.2]
+        data2 = cocoSim("GP", 2, [0.25, 0.05, 0.1, 0.1, 1.0], 60, nothing, "log", 20)
+        fit2 = cocoReg("GP", 2, data2)
+        compute_scores(fit2, 10)
+        cocoPit(fit2, 5)
+        cocoPredictOneStep(fit2, 0:5)
 
-    k = n
-
-    cov_x = reshape(sin.(1:k) .+ 4.2, :, 1)
-    cov_x_p1 = reshape(sin.((k+1):(k+3)) .+ 4.2, :, 1)
-
-    pars = []
-
-    Random.seed!(3)
-
-    for (type, order, link, covs, lambda) in product(types, orders, links, covariates, lambdas)
-
-        if order == 1
-            pars = copy(parameter_1)
-        elseif order == 2
-            pars = copy(parameter_2)
-        end
-
-        append!(pars, lambda)
-
-        if type == "GP"
-            insert!(pars, length(pars), 0.2)
-        end
-
-        if covs
-            pars[end] = lambda
-            cov_sim = copy(cov_x)
-            cov_reg = copy(cov_x)
-            cov_pred = copy(cov_x[1:1, :])
-        else
-            cov_sim = nothing
-            cov_reg = nothing
-            cov_pred = nothing
-        end
-
-        if link == "log"
-            cov_sim = log.(copy(cov_x))
-            cov_reg = log.(copy(cov_x))
-            cov_pred = log.(copy(cov_x[1:1, :]))
-        end
-
-        data = cocoSim(type, order, pars, n, cov_sim,
-                            link, 50)
-
-        fit = cocoReg(type, order, data, cov_reg)
-
-        cocoBoot(fit, [1:1:21;], 10)
-
-        cocoPit(fit)
-
-        compute_scores(fit)
-
-        cocoPredictOneStep(fit, 0:Int(ceil(maximum(data) * 1.5)), cov_pred)
-
-        cocoPredictKsteps(fit, 1, 50, cov_pred)
+        covariates = hcat(ones(60), sin.((1:60) ./ 6))
+        data3 = cocoSim("GP", 1, [0.3, 0.1, 0.5, 0.2], 60, covariates, "log", 0)
+        cocoReg("GP", 1, data3, covariates)
     end
 end

--- a/src/Scores.jl
+++ b/src/Scores.jl
@@ -1,256 +1,149 @@
 export cocoPit, compute_scores
 
+function _fit_eta(cocoReg_fit)
+    order = Int(cocoReg_fit["order"])
+    cocoReg_fit["type"] == "Poisson" && return 0.0
+    return Float64(cocoReg_fit["parameter"][order == 1 ? 2 : 4])
+end
+
+function _fit_lambdas(cocoReg_fit, n::Integer)
+    lambda = get_lambda(cocoReg_fit, false)
+    isnothing(cocoReg_fit["covariates"]) && return fill(Float64(lambda), n)
+    return Float64.(lambda)
+end
+
+"""
+    _constant_kernel(cocoReg_fit, data, lambdas, eta, xmax_hint)
+
+One shared [`GP2Kernel`](@ref) for all observations of a constant-rate
+second-order fit (sized to cover every transition and `xmax_hint`), `nothing`
+otherwise.
+"""
+function _constant_kernel(cocoReg_fit, data::Vector{Int}, lambdas, eta::Real,
+        xmax_hint::Integer)
+    (Int(cocoReg_fit["order"]) == 2 && isnothing(cocoReg_fit["covariates"])) ||
+        return nothing
+    parameter = cocoReg_fit["parameter"]
+    return GP2Kernel(lambdas[1], parameter[1], parameter[2], parameter[3], eta,
+        max(xmax_hint, 2 * maximum(data)))
+end
+
+"""
+    _transition_pmf(cocoReg_fit, t, xmax, data, lambdas, eta, kernel)
+
+Transition pmf `P(x | past)` for observation `t` on `0:xmax`, dispatching on
+the model order. Reuses `kernel` when one was prebuilt by
+[`_constant_kernel`](@ref).
+"""
+function _transition_pmf(cocoReg_fit, t::Integer, xmax::Integer,
+        data::Vector{Int}, lambdas, eta::Real, kernel)
+    parameter = cocoReg_fit["parameter"]
+    if Int(cocoReg_fit["order"]) == 1
+        return convolution_pmf_vector(xmax, data[t - 1], lambdas[t], parameter[1], eta)
+    end
+    y, z = data[t - 1], data[t - 2]
+    if kernel === nothing
+        kernel = GP2Kernel(lambdas[t], parameter[1], parameter[2], parameter[3], eta,
+            max(xmax, y + z))
+    end
+    return convolution_pmf_vector(kernel, xmax, y, z, cocoReg_fit["max_loop"])
+end
+
 """
     cocoPit(cocoReg_fit, n_bins=21)
 
-Calculates the Probability Integral Transform (PIT) histogram for a fitted count regression model.
-
-# Arguments
-- `cocoReg_fit`: A dictionary containing the fitted model results. Expected keys include `"data"`, `"parameter"`, `"order"`, `"type"`, and optionally `"covariates"` and `"max_loop"`.
-- `n_bins` (optional): An integer specifying the number of bins to use for the PIT histogram (default is 21).
-
-# Returns
-A dictionary with:
-- `"Pit_values"`: A vector of differences between consecutive PIT values, representing the estimated histogram probabilities.
-- `"bins"`: A vector of bin edge values (excluding the initial zero).
+Non-randomized Probability Integral Transform histogram of a fitted model
+(Czado et al., 2009). Each observation's cumulative transition probabilities
+are obtained from a single pmf pass. Returns a `Dict` with keys
+`"Pit_values"` and `"bins"`.
 """
-function cocoPit(cocoReg_fit, n_bins=21)
-    cocoReg_fit["data"] = Int.(cocoReg_fit["data"])
-    u = collect( range(0, stop = 1, length = Int(n_bins+1)) )
-  
-    lambda = get_lambda(cocoReg_fit, false)
-    if isnothing(cocoReg_fit["covariates"])
-      lambda = repeat([lambda], length(cocoReg_fit["data"]) )
-    end
-  
-    if cocoReg_fit["order"] == 1
-        if cocoReg_fit["type"] == "Poisson"
-            eta = 0
-        else
-            eta = cocoReg_fit["parameter"][2]
-        end
-        Px = [compute_distribution_convolution_x_r_y(cocoReg_fit["data"][t],
-                    cocoReg_fit["data"][t-1], lambda[t], cocoReg_fit["parameter"][1],
-                     eta) for t in 2:length(cocoReg_fit["data"])]
-        Pxm1 = [compute_distribution_convolution_x_r_y(cocoReg_fit["data"][t]-1,
-                cocoReg_fit["data"][t-1], lambda[t], cocoReg_fit["parameter"][1],
-                eta) for t in 2:length(cocoReg_fit["data"])]
-    elseif cocoReg_fit["order"] == 2
-        if cocoReg_fit["type"] == "Poisson"
-            eta = 0
-        else
-            eta = cocoReg_fit["parameter"][4]
-        end
-        Px = [compute_distribution_convolution_x_r_y_z(cocoReg_fit["data"][t],
-                                cocoReg_fit["data"][t-1], cocoReg_fit["data"][t-2],
-                                cocoReg_fit["parameter"][1], cocoReg_fit["parameter"][2],
-                                cocoReg_fit["parameter"][3], lambda[t],
-                                eta, cocoReg_fit["max_loop"]) for t in 3:length(cocoReg_fit["data"])]
-        Pxm1 = [compute_distribution_convolution_x_r_y_z(cocoReg_fit["data"][t]-1,
-                    cocoReg_fit["data"][t-1], cocoReg_fit["data"][t-2],
-                    cocoReg_fit["parameter"][1], cocoReg_fit["parameter"][2],
-                    cocoReg_fit["parameter"][3], lambda[t],
-                    eta, cocoReg_fit["max_loop"]) for t in 3:length(cocoReg_fit["data"])]
-    end
-  
-    uniform_distribution = [get_pit_value(Px, Pxm1, u[s]) for s in 1:(Int(n_bins+1))]
-  
-    return Dict("Pit_values" => [uniform_distribution[s] - uniform_distribution[s-1] for s in 2:(Int(n_bins+1))],
-                "bins" => u[2:end])
-end
+function cocoPit(cocoReg_fit, n_bins = 21)
+    n_bins = Int(n_bins)
+    data = Int.(cocoReg_fit["data"])
+    n = length(data)
+    order = Int(cocoReg_fit["order"])
+    eta = _fit_eta(cocoReg_fit)
+    lambdas = _fit_lambdas(cocoReg_fit, n)
 
+    first_t = order + 1
+    kernel = _constant_kernel(cocoReg_fit, data, lambdas, eta, maximum(data))
+    Px = Vector{Float64}(undef, n - order)
+    Pxm1 = Vector{Float64}(undef, n - order)
+    for t in first_t:n
+        pmf = _transition_pmf(cocoReg_fit, t, data[t], data, lambdas, eta, kernel)
+        cdf_x = sum(pmf)
+        Px[t - order] = cdf_x
+        Pxm1[t - order] = cdf_x - pmf[data[t] + 1]
+    end
+
+    u = collect(range(0, stop = 1, length = n_bins + 1))
+    uniform_distribution = [get_pit_value(Px, Pxm1, u[s]) for s in 1:(n_bins + 1)]
+
+    return Dict{String, Any}(
+        "Pit_values" => [uniform_distribution[s] - uniform_distribution[s - 1]
+                         for s in 2:(n_bins + 1)],
+        "bins" => u[2:end])
+end
 
 """
     get_pit_value(Px, Pxm1, u)
 
-Computes a PIT (Probability Integral Transform) value for a given threshold using the cumulative probabilities.
-
-# Arguments
-- `Px`: The cumulative probability at the observed count.
-- `Pxm1`: The cumulative probability at one less than the observed count.
-- `u`: A threshold value from a uniform grid [0, 1].
-
-# Returns
-The mean PIT value after constraining the computed values to the [0, 1] interval.
+Mean of the conditional PIT at threshold `u` given the cumulative
+probabilities at (`Px`) and just below (`Pxm1`) each observation.
 """
 function get_pit_value(Px, Pxm1, u)
     value = (u .- Pxm1) ./ (Px .- Pxm1)
-    value[value .<  0] .= 0
-    value[value .>  1] .= 1
-  
+    value[value .< 0] .= 0
+    value[value .> 1] .= 1
     return mean(value)
 end
 
-
 """
-    compute_scores(cocoReg_fit, max_x = 50)
+    compute_scores(cocoReg_fit, max_x=50)
 
-Computes scoring metrics for a fitted count regression model. The scores include the logarithmic score, quadratic score, and ranked probability score.
+Logarithmic, quadratic and ranked probability scores of a fitted model. For
+each observation the transition pmf on `0:max_x` is computed once and all
+three scores are derived from it (previously each score recomputed the pmf
+from scratch, making this quadratic in `max_x`).
 
-# Arguments
-- `cocoReg_fit`: A dictionary containing the fitted model results with keys such as `"data"`, `"parameter"`, `"order"`, `"type"`, and optionally `"covariates"` and `"max_loop"`.
-- `max_x` (optional): The maximum count value to use when summing the probability mass function (default is 50).
-
-# Returns
-A dictionary with the following keys:
-- `"logarithmic_score"`: The average negative log-probability of the observed counts.
-- `"quadratic_score"`: The average quadratic score based on computed probabilities and the h-index.
-- `"ranked_probability_score"`: The average ranked probability score.
+Returns a `Dict` with keys `"logarithmic_score"`, `"quadratic_score"` and
+`"ranked_probability_score"`.
 """
 function compute_scores(cocoReg_fit, max_x = 50)
-  
-    lambda = get_lambda(cocoReg_fit, false)
-  
-    if isnothing(cocoReg_fit["covariates"])
-      lambda = repeat([lambda], length(cocoReg_fit["data"]) )
-    end
-  
-    if Int(cocoReg_fit["order"]) == 1
-        if cocoReg_fit["type"] == "Poisson"
-            eta = 0
-        else
-            eta = cocoReg_fit["parameter"][2]
+    max_x = Int(max_x)
+    data = Int.(cocoReg_fit["data"])
+    n = length(data)
+    order = Int(cocoReg_fit["order"])
+    eta = _fit_eta(cocoReg_fit)
+    lambdas = _fit_lambdas(cocoReg_fit, n)
+
+    first_t = order + 1
+    n_terms = n - order
+    kernel = _constant_kernel(cocoReg_fit, data, lambdas, eta, max_x)
+    log_score_sum = 0.0
+    quad_score_sum = 0.0
+    rps_sum = 0.0
+
+    for t in first_t:n
+        x = data[t]
+        pmf = _transition_pmf(cocoReg_fit, t, max(max_x, x), data, lambdas, eta, kernel)
+
+        log_score_sum -= log(pmf[x + 1])
+
+        h_index = 0.0
+        cdf = 0.0
+        rps = 0.0
+        @inbounds for s in 0:max_x
+            p = pmf[s + 1]
+            h_index += p^2
+            cdf += p
+            rps += (x <= s ? 1 - cdf : cdf)^2
         end
-  
-        probabilities = [compute_convolution_x_r_y(cocoReg_fit["data"][t],
-                         cocoReg_fit["data"][t-1], lambda[t], cocoReg_fit["parameter"][1],
-                         eta) for t in 2:length(cocoReg_fit["data"])]
-                               
-        h_index = [compute_h_index_1(cocoReg_fit["data"][t-1], lambda[t],
-                        cocoReg_fit["parameter"][1],
-                         eta, max_x) for t in 2:length(cocoReg_fit["data"])]
-  
-        rbs = [compute_ranked_probability_helper_1(cocoReg_fit["data"][t],
-                         cocoReg_fit["data"][t-1], lambda[t], cocoReg_fit["parameter"][1],
-                         eta, max_x) for t in 2:length(cocoReg_fit["data"])]
-  
-    elseif Int(cocoReg_fit["order"]) == 2
-        if cocoReg_fit["type"] == "Poisson"
-            eta = 0
-        else
-            eta = cocoReg_fit["parameter"][4]
-        end
-  
-        probabilities = [compute_convolution_x_r_y_z(cocoReg_fit["data"][t],
-                        cocoReg_fit["data"][t-1], cocoReg_fit["data"][t-2], lambda[t],
-                        cocoReg_fit["parameter"][1],
-                        cocoReg_fit["parameter"][2], cocoReg_fit["parameter"][3],
-                         eta, cocoReg_fit["max_loop"]) for t in 3:length(cocoReg_fit["data"])]
-  
-        h_index = [compute_h_index_2(cocoReg_fit["data"][t-1], cocoReg_fit["data"][t-2],
-                                    cocoReg_fit["parameter"][1],
-                        cocoReg_fit["parameter"][2], cocoReg_fit["parameter"][3],
-                        lambda[t],
-                         eta, cocoReg_fit["max_loop"], max_x) for t in 3:length(cocoReg_fit["data"])]
-  
-        rbs = [compute_ranked_probability_helper_2(cocoReg_fit["data"][t],
-                        cocoReg_fit["data"][t-1], cocoReg_fit["data"][t-2],
-                        cocoReg_fit["parameter"][1],
-                        cocoReg_fit["parameter"][2], cocoReg_fit["parameter"][3],
-                        lambda[t],
-                        eta, cocoReg_fit["max_loop"], max_x) for t in 3:length(cocoReg_fit["data"])]
+        quad_score_sum += h_index - 2 * pmf[x + 1]
+        rps_sum += rps
     end
-  
-    return Dict("logarithmic_score" => Float64(- sum(log.(probabilities)) / length(probabilities)),
-                "quadratic_score" => Float64(sum(- 2 .* probabilities .+ h_index) / length(probabilities)),
-                "ranked_probability_score" => Float64(sum(rbs) / length(probabilities))
-                )
+
+    return Dict{String, Any}("logarithmic_score" => log_score_sum / n_terms,
+        "quadratic_score" => quad_score_sum / n_terms,
+        "ranked_probability_score" => rps_sum / n_terms)
 end
-
-
-"""
-    compute_h_index_1(y, lambda, alpha, eta, max_x = 50)
-
-Computes the h-index for a first-order count regression model by summing the squared probabilities of the convolution distribution over a range of count values.
-
-# Arguments
-- `y`: The lagged observed count (previous time step).
-- `lambda`: The rate parameter for the current observation.
-- `alpha`: The autoregressive parameter.
-- `eta`: The dispersion parameter.
-- `max_x` (optional): The maximum count value to consider (default is 50).
-
-# Returns
-A scalar representing the h-index as the sum of squared probabilities.
-"""
-function compute_h_index_1(y, lambda, alpha, eta, max_x = 50)
-    return sum(([compute_convolution_x_r_y(s, y, lambda, alpha, eta) for s in 0:Int(max_x)]).^2)
-end
-
-
-"""
-    compute_ranked_probability_helper_1(x, y, lambda, alpha, eta, max_x = 50)
-
-Computes a helper value for the ranked probability score in a first-order count regression model. The helper is obtained by summing the squared differences between the cumulative distribution and the observed count indicator.
-
-# Arguments
-- `x`: The observed count value.
-- `y`: The lagged count value.
-- `lambda`: The rate parameter for the current observation.
-- `alpha`: The autoregressive parameter.
-- `eta`: The dispersion parameter.
-- `max_x` (optional): The maximum count value to consider (default is 50).
-
-# Returns
-A scalar value representing the ranked probability score helper.
-"""
-function compute_ranked_probability_helper_1(x, y, lambda, alpha, eta, max_x = 50)
-    dist_val = [compute_distribution_convolution_x_r_y(s, y, lambda, alpha, eta) for s in 0:Int(max_x)]
-    return sum(((x .<= 0:(length(dist_val)-1)) .* (1 .- dist_val) .+ (x .> 0:(length(dist_val)-1)) .* dist_val).^2)
-end
-
-
-"""
-    compute_h_index_2(y, z, alpha1, alpha2, alpha3, lambda, eta, max_loop=nothing, max_x = 50)
-
-Computes the h-index for a second-order count regression model by summing the squared probabilities of the convolution distribution over a range of count values.
-
-# Arguments
-- `y`: The first lagged count value.
-- `z`: The second lagged count value.
-- `alpha1`: The first autoregressive parameter.
-- `alpha2`: The second autoregressive parameter.
-- `alpha3`: The third autoregressive parameter.
-- `lambda`: The rate parameter for the current observation.
-- `eta`: The dispersion parameter.
-- `max_loop` (optional): A parameter controlling the maximum iterations or truncation for the convolution calculation (default is `nothing`).
-- `max_x` (optional): The maximum count value to consider (default is 50).
-
-# Returns
-A scalar representing the h-index as the sum of squared probabilities.
-"""
-function compute_h_index_2(y, z, alpha1, alpha2, alpha3, lambda, eta, max_loop=nothing, max_x = 50)
-    return sum(([compute_convolution_x_r_y_z(s, y, z, lambda, alpha1, alpha2, alpha3,
-                                                 eta, max_loop) for s in 0:Int(max_x)]).^2)
-end
-
-
-"""
-    compute_ranked_probability_helper_2(x, y, z, alpha1, alpha2, alpha3,
-                                        lambda, eta, max_loop=nothing, max_x = 50)
-
-Computes a helper value for the ranked probability score in a second-order count regression model. The helper is computed by summing the squared differences based on the convolution distribution for counts from 0 to `max_x`.
-
-# Arguments
-- `x`: The observed count value.
-- `y`: The first lagged count value.
-- `z`: The second lagged count value.
-- `alpha1`: The first autoregressive parameter.
-- `alpha2`: The second autoregressive parameter.
-- `alpha3`: The third autoregressive parameter.
-- `lambda`: The rate parameter for the current observation.
-- `eta`: The dispersion parameter.
-- `max_loop` (optional): A parameter controlling the maximum iterations or truncation in the convolution calculation (default is `nothing`).
-- `max_x` (optional): The maximum count value to consider (default is 50).
-
-# Returns
-A scalar representing the ranked probability score helper for the second-order model.
-"""
-function compute_ranked_probability_helper_2(x, y, z, alpha1, alpha2, alpha3,
-                                             lambda, eta, max_loop=nothing, max_x = 50)
-    dist_val = [compute_distribution_convolution_x_r_y_z(s, y, z, alpha1, alpha2, alpha3,
-                                                lambda, eta, max_loop) for s in 0:Int(max_x)]
-    return sum(((x .<= 0:(length(dist_val)-1)) .* (dist_val .- 1) .+ (x .> 0:(length(dist_val)-1)) .* dist_val).^2)
-end
-
-

--- a/src/StartingValues.jl
+++ b/src/StartingValues.jl
@@ -1,55 +1,25 @@
 """
-    get_starting_values!(type, order, data, covariates, starting_values, n_parameter_without, lower_bound_covariates)
+    get_starting_values!(type, order, data, covariates, starting_values,
+                         n_parameter_without, lower_bound_covariates)
 
-If starting values are not provided, computes starting values for model parameters based on the specified model type ("GP" or "Poisson")
-and order (1 or 2). For models with covariates, it adjusts the starting values for the covariate parameters by appending a constant value derived
-from the lower bound.
-
-# Arguments
-- `type`: A string specifying the model type ("GP" for generalized Poisson or "Poisson").
-- `order`: The autoregressive order (1 or 2).
-- `data`: A vector of observed counts.
-- `covariates`: A matrix of covariates (or `nothing` if none).
-- `starting_values`: A vector of initial parameter values; if provided, these values are used.
-- `n_parameter_without`: The number of parameters before including the covariate parameters.
-- `lower_bound_covariates`: A numeric lower bound for the covariate parameters.
-
-# Returns
-A vector of starting values for the model parameters.
+Returns `starting_values` unchanged when provided; otherwise computes
+data-driven starting values for the requested model. For covariate models the
+innovation-rate start is replaced by per-coefficient starts respecting
+`lower_bound_covariates`.
 """
-function get_starting_values!(type, order, data, covariates, starting_values, n_parameter_without, lower_bound_covariates)
-    if isnothing(starting_values)
-        if (type == "GP") & (order == 2)
-            starting_values = compute_starting_values_GP2_reparameterized("GP", data)
-            if !isnothing(covariates)
-                starting_values[n_parameter_without+1] = max(0, lower_bound_covariates + 1e-08)
-                starting_values = vcat(starting_values, repeat([max(0, lower_bound_covariates + 1e-08)], size(covariates, 2)-1))
-            end
-        end
-
-        if (type == "Poisson") & (order == 2)
-            starting_values = compute_starting_values_GP2_reparameterized("Poisson", data)
-            if !isnothing(covariates)
-                starting_values[n_parameter_without+1] = max(0, lower_bound_covariates + 1e-08)
-                starting_values = vcat(starting_values, repeat([max(0, lower_bound_covariates + 1e-08)], size(covariates, 2)-1))
-            end
-        end
-
-        if (type == "GP") & (order == 1)
-            starting_values = compute_starting_values_GP1("GP", data)
-            if !isnothing(covariates)
-                starting_values[n_parameter_without+1] = max(0, lower_bound_covariates + 1e-08)
-                starting_values = vcat(starting_values, repeat([max(0, lower_bound_covariates + 1e-08)], size(covariates, 2)-1))
-            end
-        end
-
-        if (type == "Poisson") & (order == 1)
-            starting_values = compute_starting_values_GP1("Poisson", data)
-            if !isnothing(covariates)
-                starting_values[n_parameter_without+1] = max(0, lower_bound_covariates + 1e-08)
-                starting_values = vcat(starting_values, repeat([max(0, lower_bound_covariates + 1e-08)], size(covariates, 2)-1))
-            end
-        end
+function get_starting_values!(type, order, data, covariates, starting_values,
+        n_parameter_without, lower_bound_covariates)
+    isnothing(starting_values) || return starting_values
+    if Int(order) == 2
+        starting_values = compute_starting_values_GP2_reparameterized(type, data)
+    else
+        starting_values = compute_starting_values_GP1(type, data)
+    end
+    if !isnothing(covariates)
+        beta_start = max(0, lower_bound_covariates + 1e-08)
+        starting_values[Int(n_parameter_without) + 1] = beta_start
+        starting_values = vcat(starting_values,
+            fill(beta_start, size(covariates, 2) - 1))
     end
     return starting_values
 end
@@ -57,97 +27,57 @@ end
 """
     compute_starting_values_GP2_reparameterized(type, data)
 
-Computes starting values for a second-order model using a reparameterization approach.
-It estimates the autoregressive parameters (alpha1, alpha2, alpha3) based on autocorrelations and a third moment measure,
-computes a starting value for the dispersion parameter (eta) if applicable, and calculates the rate parameter lambda.
-
-# Arguments
-- `type`: A string indicating the model type ("GP" for generalized Poisson or "Poisson").
-- `data`: A vector of observed counts.
-
-# Returns
-For "GP" models, returns a vector:  
-`[2*alpha1 + alpha3, alpha3 / (2*alpha1+alpha3), alpha2 / (1-alpha1-alpha3), eta, lambda]`.  
-For "Poisson" models, returns:  
-`[2*alpha1 + alpha3, alpha3 / (2*alpha1+alpha3), alpha2 / (1-alpha1-alpha3), lambda]`.
+Data-driven starting values for second-order models on the reparameterized
+scale: `[2*alpha1 + alpha3, alpha3 / (2*alpha1 + alpha3),
+alpha2 / (1 - alpha1 - alpha3)[, eta], lambda]`.
 """
 function compute_starting_values_GP2_reparameterized(type, data)
-    if type == "GP"
-        eta = compute_eta_starting_value(data)
-    elseif type == "Poisson"
-        eta = 0
-    end
-    alpha3 = set_to_unit_interval(compute_mu_hat_gmm(data) / mean(data) / (1 + 2 * eta) * (1 - eta)^4)
+    eta = type == "GP" ? compute_eta_starting_value(data) : 0.0
+    alpha3 = set_to_unit_interval(compute_mu_hat_gmm(data) / mean(data) /
+                                  (1 + 2 * eta) * (1 - eta)^4)
     alpha1 = set_to_unit_interval(compute_autocorrelation(data, 1))
     alpha2 = set_to_unit_interval(compute_autocorrelation(data, 2))
 
-    if alpha3 + alpha2 + alpha1 >= 1
-        while alpha3 + alpha2 + alpha1 >= 1
-            alpha3 = alpha3 * 0.8
-            alpha2 = alpha2 * 0.8
-            alpha1 = alpha1 * 0.8
-        end
+    while alpha3 + alpha2 + alpha1 >= 1
+        alpha3 *= 0.8
+        alpha2 *= 0.8
+        alpha1 *= 0.8
     end
-
-    if alpha3 + 2 * alpha1 >= 1
-        while alpha3 + 2 * alpha1 >= 1
-            alpha3 = alpha3 * 0.8
-            alpha1 = alpha2 * 0.8
-        end
+    while alpha3 + 2 * alpha1 >= 1
+        alpha3 *= 0.8
+        alpha1 *= 0.8
     end
 
     lambda = mean(data) * (1 - alpha1 - alpha2 - alpha3) * (1 - eta)
 
+    reparameterized = [2 * alpha1 + alpha3, alpha3 / (2 * alpha1 + alpha3),
+        alpha2 / (1 - alpha1 - alpha3)]
     if type == "GP"
-        return [2 * alpha1 + alpha3, alpha3 / (2 * alpha1 + alpha3), alpha2 / (1 - alpha1 - alpha3), eta, lambda]
-    elseif type == "Poisson"
-        return [2 * alpha1 + alpha3, alpha3 / (2 * alpha1 + alpha3), alpha2 / (1 - alpha1 - alpha3), lambda]
+        return vcat(reparameterized, [eta, lambda])
     end
+    return vcat(reparameterized, [lambda])
 end
 
 """
     compute_starting_values_GP1(type, data)
 
-Computes starting values for a first-order model.
-It estimates the autoregressive parameter (alpha) from the first-order autocorrelation and computes the rate parameter lambda accordingly.
-For "GP" models, it also computes a starting value for the dispersion parameter (eta).
-
-# Arguments
-- `type`: A string indicating the model type ("GP" for generalized Poisson or "Poisson").
-- `data`: A vector of observed counts.
-
-# Returns
-For "GP" models, returns a vector `[alpha, eta, lambda]`.  
-For "Poisson" models, returns a vector `[alpha, lambda]`.
+Data-driven starting values for first-order models: `[alpha[, eta], lambda]`.
 """
 function compute_starting_values_GP1(type, data)
     alpha = abs(compute_autocorrelation(data, 1))
     lambda = mean(data) * (1 - alpha)
     if type == "GP"
-        eta = compute_eta_starting_value(data)
-        return [alpha, eta, lambda]
-    elseif type == "Poisson"
-        eta = 0
-        return [alpha, lambda]
+        return [alpha, compute_eta_starting_value(data), lambda]
     end
+    return [alpha, lambda]
 end
 
 """
     compute_eta_starting_value(data)
 
-Computes a starting value for the dispersion parameter (eta) based on the observed data.
-Eta is computed as `1 - sqrt(mean(data) / var(data))` and is set to a small positive value if the result is negative.
-
-# Arguments
-- `data`: A vector of observed counts.
-
-# Returns
-A non-negative value for eta, with a minimum of 0.0001.
+Dispersion starting value `1 - sqrt(mean / var)`, floored at `0.0001`.
 """
 function compute_eta_starting_value(data)
-    eta = 1 - (mean(data) / var(data))^0.5
-    if eta < 0
-        eta = 0.0001
-    end
-    return eta
+    eta = 1 - sqrt(mean(data) / var(data))
+    return eta < 0 ? 0.0001 : eta
 end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,157 +1,80 @@
-using LinearAlgebra
-
 """
     compute_beta_i(lambda, U, alpha_i)
 
-Computes beta_i as the product of lambda, U, and alpha_i.
-
-# Arguments
-- `lambda`: The rate parameter.
-- `U`: A scaling factor.
-- `alpha_i`: An autoregressive parameter.
-
-# Returns
-The computed beta_i value.
+Derived rate `beta_i = lambda * U * alpha_i` of the second-order model.
 """
-function compute_beta_i(lambda, U, alpha_i)
-    return lambda * U * alpha_i
-end
+compute_beta_i(lambda::Real, U::Real, alpha_i::Real) = lambda * U * alpha_i
 
 """
     compute_U(alpha1, alpha2, alpha3)
 
-Computes the scaling factor U based on the autoregressive parameters.
-
-# Arguments
-- `alpha1`: The first autoregressive parameter.
-- `alpha2`: The second autoregressive parameter.
-- `alpha3`: The third autoregressive parameter.
-
-# Returns
-The computed value of U, defined as 1 / (1 - alpha1 - alpha2 - alpha3).
+Scaling factor `U = 1 / (1 - alpha1 - alpha2 - alpha3)`.
 """
-function compute_U(alpha1, alpha2, alpha3)
-    return 1 / (1 - alpha1 - alpha2 - alpha3)
-end
+compute_U(alpha1::Real, alpha2::Real, alpha3::Real) = 1 / (1 - alpha1 - alpha2 - alpha3)
 
 """
     compute_zeta(lambda, U, alpha1, alpha3)
 
-Computes zeta using the provided parameters.
-
-# Arguments
-- `lambda`: The rate parameter.
-- `U`: A scaling factor computed from autoregressive parameters.
-- `alpha1`: The first autoregressive parameter.
-- `alpha3`: The third autoregressive parameter.
-
-# Returns
-The computed value of zeta, defined as lambda * U * (1 - 2*alpha1 - alpha3).
+Derived rate `zeta = lambda * U * (1 - 2*alpha1 - alpha3)`.
 """
-function compute_zeta(lambda, U, alpha1, alpha3)
-    return lambda * U * (1 - 2 * alpha1 - alpha3)
-end
+compute_zeta(lambda::Real, U::Real, alpha1::Real, alpha3::Real) = lambda * U *
+                                                                  (1 - 2 * alpha1 - alpha3)
 
 """
     compute_inverse_matrix(M)
 
-Computes the inverse of the given matrix M.
-
-# Arguments
-- `M`: A square matrix.
-
-# Returns
-The inverse of matrix M.
+Inverse of the square matrix `M`.
 """
-function compute_inverse_matrix(M)
-    return inv(M)
-end
+compute_inverse_matrix(M::AbstractMatrix) = inv(M)
 
 """
     compute_hessian(f, x)
 
-Computes the Hessian matrix of a function f at the point x using automatic differentiation.
-
-# Arguments
-- `f`: A function for which the Hessian is to be computed.
-- `x`: The point (vector) at which the Hessian is evaluated.
-
-# Returns
-The Hessian matrix of f evaluated at x.
+Hessian of `f` at `x` via ForwardDiff.
 """
-function compute_hessian(f, x)
-    return ForwardDiff.hessian(f, x)
-end
+compute_hessian(f, x::AbstractVector) = ForwardDiff.hessian(f, x)
 
 """
     compute_mu_hat_gmm(data)
 
-Computes the GMM estimator (mu_hat) based on third-order moments of the data.
-
-# Arguments
-- `data`: A vector of data points.
-
-# Returns
-The computed mu_hat, defined as the average of the product of deviations 
-(data[t] - x̄) * (data[t-1] - x̄) * (data[t-2] - x̄) over t = 3 to length(data).
+GMM estimator based on centered third-order moments of `data`.
 """
-function compute_mu_hat_gmm(data)
-    sum = 0.0
+function compute_mu_hat_gmm(data::AbstractVector)
+    total = 0.0
     x_bar = mean(data)
-    for t in eachindex(data)[3:end]
-        sum = sum + (data[t] - x_bar) * (data[t-1] - x_bar) * (data[t-2] - x_bar)
+    for t in 3:length(data)
+        total += (data[t] - x_bar) * (data[t - 1] - x_bar) * (data[t - 2] - x_bar)
     end
-    return sum / length(data)
+    return total / length(data)
 end
 
 """
     compute_autocorrelation(data, order)
 
-Computes the autocorrelation of the data with a specified lag order.
-
-# Arguments
-- `data`: A vector of data points.
-- `order`: The lag order to compute the autocorrelation.
-
-# Returns
-The Pearson correlation coefficient between the original data and its lagged version.
+Pearson correlation between `data` and its `order`-lagged version.
 """
-function compute_autocorrelation(data, order)
-    x_t = data[1:(length(data)-order)]
-    x_lag = data[(order+1):length(data)]
+function compute_autocorrelation(data::AbstractVector, order::Integer)
+    x_t = @view data[1:(length(data) - order)]
+    x_lag = @view data[(order + 1):length(data)]
     return cor(x_t, x_lag)
 end
 
 """
     set_to_unit_interval(x)
 
-Constrains the value x to be within the unit interval [0.0001, 0.9999].
-
-# Arguments
-- `x`: A numeric value.
-
-# Returns
-x clamped to the interval [0.0001, 0.9999].
+Clamps `x` to `[0.0001, 0.9999]`.
 """
-function set_to_unit_interval(x)
-    return max(min(x, 0.9999), 0.0001)
-end
+set_to_unit_interval(x::Real) = clamp(x, 0.0001, 0.9999)
 
 """
     reparameterize_alpha(parameter)
 
-Reparameterizes the alpha parameters from a given parameter vector.
-
-# Arguments
-- `parameter`: A vector containing at least three elements used for reparameterization.
-
-# Returns
-A tuple `(alpha1, alpha2, alpha3)` computed as follows:
-- `alpha3` = parameter[1] * parameter[2]
-- `alpha1` = (parameter[1] - alpha3) / 2
-- `alpha2` = (1 - alpha1 - alpha3) * parameter[3]
+Maps the stationarity-preserving optimization parameters of the second-order
+model back to `(alpha1, alpha2, alpha3)`:
+`alpha3 = p1 * p2`, `alpha1 = (p1 - alpha3) / 2`,
+`alpha2 = (1 - alpha1 - alpha3) * p3`.
 """
-function reparameterize_alpha(parameter)
+function reparameterize_alpha(parameter::AbstractVector)
     alpha3 = parameter[1] * parameter[2]
     alpha1 = (parameter[1] - alpha3) / 2
     alpha2 = (1 - alpha1 - alpha3) * parameter[3]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,7 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,66 +1,208 @@
 using Coconots
 using Test
 using Random
-using Base.Iterators: product
+using ForwardDiff
+using Statistics: mean
 
-@testset "compute_distribution_convolution_x_r_y" begin
-    # Test that negative x returns 0
-    @test Coconots.compute_distribution_convolution_x_r_y(-1, 10, 1.0, 0.5, 1.0) == 0
+@testset "convolution distributions (order 1)" begin
+    y = 10
+    λ = 2.0
+    α = 0.5
+    η = 1.0
+    @test Coconots.compute_distribution_convolution_x_r_y(-1, y, λ, α, η) == 0
 
-    # Test that for x = 0 the cumulative equals the likelihood at 0
-    y = 10; λ = 2.0; α = 0.5; η = 1.0
     result_cum = Coconots.compute_distribution_convolution_x_r_y(0, y, λ, α, η)
     result_single = Coconots.compute_convolution_x_r_y(0, y, λ, α, η)
-    @test isapprox(result_cum, result_single; atol=1e-8)
+    @test isapprox(result_cum, result_single; atol = 1e-8)
 
-    # For a positive x, check that the cumulative is the sum of individual likelihoods.
     x = 3
     expected = sum([Coconots.compute_convolution_x_r_y(i, y, λ, α, η) for i in 0:x])
-    @test isapprox(Coconots.compute_distribution_convolution_x_r_y(x, y, λ, α, η), expected; atol=1e-8)
+    @test isapprox(Coconots.compute_distribution_convolution_x_r_y(x, y, λ, α, η),
+        expected; atol = 1e-8)
+
+    # transition pmf sums to one over its support
+    @test isapprox(Coconots.compute_distribution_convolution_x_r_y(200, 4, 1.5, 0.4,
+            0.2),
+        1.0; atol = 1e-8)
+
+    # pmf vector matches pointwise evaluation
+    pmf = Coconots.convolution_pmf_vector(6, 4, 1.5, 0.4, 0.2)
+    @test pmf ≈
+          [Coconots.compute_convolution_x_r_y(i, 4, 1.5, 0.4, 0.2) for i in 0:6]
 end
 
-@testset "compute_distribution_convolution_x_r_y_z" begin
-    # Negative x should return 0
-    @test Coconots.compute_distribution_convolution_x_r_y_z(-1, 10, 5, 0.3, 0.2, 0.1, 2.0, 1.0) == 0
+@testset "convolution distributions (order 2)" begin
+    y = 10
+    z = 5
+    λ = 2.0
+    α1 = 0.3
+    α2 = 0.2
+    α3 = 0.1
+    η = 1.0
+    @test Coconots.compute_distribution_convolution_x_r_y_z(-1, y, z, α1, α2, α3, λ,
+        η) == 0
 
-    # For x = 0, the cumulative should match the single convolution likelihood at 0.
-    y = 10; z = 5; λ = 2.0; α1 = 0.3; α2 = 0.2; α3 = 0.1; η = 1.0
-    result_cum = Coconots.compute_distribution_convolution_x_r_y_z(0, y, z, α1, α2, α3, λ, η)
+    result_cum = Coconots.compute_distribution_convolution_x_r_y_z(0, y, z, α1, α2, α3,
+        λ, η)
     result_single = Coconots.compute_convolution_x_r_y_z(0, y, z, λ, α1, α2, α3, η)
-    @test isapprox(result_cum, result_single; atol=1e-8)
+    @test isapprox(result_cum, result_single; atol = 1e-8)
 
-    # For x > 0, check that the cumulative equals the sum of individual likelihoods.
     x = 3
-    expected = sum([Coconots.compute_convolution_x_r_y_z(i, y, z, λ, α1, α2, α3, η) for i in 0:x])
-    @test isapprox(Coconots.compute_distribution_convolution_x_r_y_z(x, y, z, α1, α2, α3, λ, η), expected; atol=1e-8)
+    expected = sum([Coconots.compute_convolution_x_r_y_z(i, y, z, λ, α1, α2, α3, η)
+                    for i in 0:x])
+    @test isapprox(
+        Coconots.compute_distribution_convolution_x_r_y_z(x, y, z, α1, α2,
+            α3, λ, η),
+        expected; atol = 1e-8)
+
+    # kernel-based pmf vector matches pointwise evaluation, and g(r | y, z) is
+    # unchanged by the one-shot wrapper
+    kernel = Coconots.GP2Kernel(λ, 0.3, 0.2, 0.1, 0.2, y + z)
+    pmf = Coconots.convolution_pmf_vector(kernel, 8, y, z, nothing)
+    @test pmf ≈ [Coconots.compute_convolution_x_r_y_z(i, y, z, λ, 0.3, 0.2, 0.1, 0.2)
+           for i in 0:8]
+    # an undersized kernel is rejected instead of reading past its tables
+    @test_throws ArgumentError Coconots.convolution_pmf_vector(kernel, 300, y, z,
+        nothing)
+    wide_kernel = Coconots.GP2Kernel(λ, 0.3, 0.2, 0.1, 0.2, 300)
+    @test isapprox(sum(Coconots.convolution_pmf_vector(wide_kernel, 300, y, z,
+            nothing)),
+        1.0; atol = 1e-8)
 end
 
+@testset "generalized Poisson pmf" begin
+    # log-space branch agrees with the table branch scaling behavior and both
+    # accept Dual numbers
+    @test Coconots.generalized_poisson_distribution(3, 2.0, 0.2) ≈
+          exp(Coconots.log_generalized_poisson_pdf(3, 2.0, 0.2))
+    d = ForwardDiff.Dual(2.0, 1.0)
+    @test Coconots.generalized_poisson_distribution(3, d, 0.2) isa ForwardDiff.Dual
+    # pmf of large counts stays finite (previously required BigInt factorials)
+    @test 0 <=
+          Coconots.generalized_poisson_distribution(250, 2.0, 0.2) <= 1
+end
+
+@testset "negative log-likelihood" begin
+    Random.seed!(11)
+    data = cocoSim("GP", 2, [0.25, 0.1, 0.1, 0.15, 1.5], 120)
+
+    # constant-rate fast path (unique transitions) equals the per-observation path
+    lambdas = fill(1.5, length(data))
+    nll_scalar = Coconots.compute_negative_log_likelihood_GP2(1.5, 0.25, 0.1, 0.1,
+        0.15, data)
+    nll_direct = sum(-log(Coconots.compute_convolution_x_r_y_z(data[t], data[t - 1],
+                         data[t - 2], 1.5, 0.25, 0.1, 0.1, 0.15)) for t in 3:length(data))
+    @test isapprox(nll_scalar, nll_direct; rtol = 1e-10)
+    @test isapprox(
+        Coconots.compute_negative_log_likelihood_GP2(lambdas, 0.25, 0.1,
+            0.1, 0.15, data),
+        nll_scalar; rtol = 1e-12)
+
+    nll1_scalar = Coconots.compute_negative_log_likelihood_GP1(1.5, 0.4, 0.15, data)
+    nll1_direct = sum(-log(Coconots.compute_convolution_x_r_y(data[t], data[t - 1],
+                          1.5, 0.4, 0.15)) for t in 2:length(data))
+    @test isapprox(nll1_scalar, nll1_direct; rtol = 1e-10)
+
+    # differentiable end to end
+    grad = ForwardDiff.gradient(
+        t -> Coconots.compute_negative_log_likelihood_GP2(t[5], t[1], t[2], t[3], t[4],
+            data), [0.25, 0.1, 0.1, 0.15, 1.5])
+    @test all(isfinite, grad)
+end
+
+@testset "cocoReg" begin
+    Random.seed!(7)
+    data = cocoSim("GP", 1, [0.4, 0.2, 2.0], 300)
+    fit = cocoReg("GP", 1, data)
+    @test length(fit["parameter"]) == 3
+    @test all(isfinite, fit["se"])
+    @test isapprox(fit["parameter"][1], 0.4; atol = 0.15)
+    @test isapprox(fit["parameter"][3], 2.0; atol = 0.5)
+    @test fit["log_likelihood"] ≈
+          -Coconots.compute_negative_log_likelihood_GP1(fit["parameter"][3],
+        fit["parameter"][1], fit["parameter"][2], Int.(data))
+
+    # assessment tools run on the fit and return the contract keys
+    scores = compute_scores(fit, 30)
+    @test all(haskey.(Ref(scores),
+        ["logarithmic_score", "quadratic_score", "ranked_probability_score"]))
+    pit = cocoPit(fit, 10)
+    @test length(pit["Pit_values"]) == 10
+    @test isapprox(sum(pit["Pit_values"]), 1.0; atol = 1e-6)
+    boot = cocoBoot(fit, [1:1:5;], 20)
+    @test size(boot["pacfs"]) == (20, 5)
+    pred = cocoPredictOneStep(fit, 0:20)
+    @test isapprox(sum(pred["probabilities"]), 1.0; atol = 1e-3)
+    predk = cocoPredictKsteps(fit, 2, 50)
+    @test predk["length"] == 2
+
+    # default transformation-based fit respects the constraints and agrees
+    # with the box-constrained solver
+    @test all(0 .<= fit["parameter"][1:2] .<= 1)
+    @test fit["parameter"][3] >= 0
+    fit_box = cocoReg("GP", 1, data; box_constrained = true)
+    @test isapprox(fit_box["parameter"], fit["parameter"]; atol = 1e-3)
+    @test isapprox(fit_box["log_likelihood"], fit["log_likelihood"]; atol = 1e-4)
+
+    @test_throws ArgumentError cocoReg("NegBin", 1, data)
+    @test_throws ArgumentError cocoReg("GP", 3, data)
+end
+
+@testset "bound transformations" begin
+    for (lo, hi) in [(0.0, 1.0), (0.0, Inf), (-Inf, Inf), (-2.0, Inf), (-Inf, 3.0)]
+        for x in [-1.5, 0.3, 2.5]
+            (lo < x < hi) || continue
+            u = Coconots._to_unconstrained(x, lo, hi)
+            @test isapprox(Coconots._to_bounded(u, lo, hi), x; rtol = 1e-6)
+        end
+        for u in [-4.0, 0.0, 4.0]
+            x = Coconots._to_bounded(u, lo, hi)
+            @test lo <= x <= hi
+        end
+    end
+end
+
+@testset "cocoReg with covariates" begin
+    Random.seed!(21)
+    n = 250
+    covariates = hcat(ones(n), sin.((1:n) ./ 12))
+    data = cocoSim("Poisson", 1, [0.3, 0.7, 0.4], n, covariates, "log", 0)
+    fit = cocoReg("Poisson", 1, data, covariates)
+    @test length(fit["parameter"]) == 3
+    @test isapprox(fit["parameter"][2], 0.7; atol = 0.4)
+    @test all(isfinite, fit["se"])
+end
+
+@testset "cocoForwardSim conditions on the last observations" begin
+    # With alpha near 1 and tiny lambda, forecasts must inherit the level of
+    # x_prev. (A previous version seeded x_prev at the end of the state vector
+    # where the simulation loop immediately overwrote it for k >= 2.)
+    Random.seed!(5)
+    forecasts = [Coconots.cocoForwardSim(2, 30, "Poisson", 1, [0.95, 0.01])
+                 for _ in 1:100]
+    @test mean(first.(forecasts)) > 20
+    @test mean(last.(forecasts)) > 15
+end
 
 @testset "get_lambda" begin
-    # When there are no covariates, get_lambda should return the last parameter.
-    cocoReg_fit = Dict("link" => "identity", "covariates" => nothing, "parameter" => [1.0, 2.0, 3.0])
-    @test Coconots.get_lambda(cocoReg_fit) == 3.0
+    fit = Dict("link" => "identity", "covariates" => nothing,
+        "parameter" => [1.0, 2.0, 3.0])
+    @test Coconots.get_lambda(fit) == 3.0
 
-    # When covariates are provided, get_lambda should compute using the link function.
-    # Here we simulate a simple linear model where the link function is identity.
-    cocoReg_fit = Dict("link" => "identity",
-                       "covariates" => [1.0 2.0; 3.0 4.0],
-                       "parameter" => [0.5, 1.5])
-    expected_all = cocoReg_fit["covariates"] * cocoReg_fit["parameter"]
-    result_all = Coconots.get_lambda(cocoReg_fit)
-    @test all(result_all .== expected_all)
-
-    # Test the `last_val` option: only the last row is used.
-    expected_last = sum(cocoReg_fit["covariates"][end, :] .* cocoReg_fit["parameter"])
-    result_last = Coconots.get_lambda(cocoReg_fit, true)
-    @test isapprox(result_last, expected_last; atol=1e-8)
+    fit = Dict("link" => "identity", "covariates" => [1.0 2.0; 3.0 4.0],
+        "parameter" => [0.5, 1.5])
+    @test all(Coconots.get_lambda(fit) .== fit["covariates"] * fit["parameter"])
+    @test isapprox(Coconots.get_lambda(fit, true),
+        sum(fit["covariates"][end, :] .* fit["parameter"]); atol = 1e-8)
 end
 
-@testset "get_link_function softplus" begin
+@testset "link functions" begin
     f = Coconots.get_link_function("softplus")
-    @test isapprox(f(0.0), log(2.0); atol=1e-10)
+    @test isapprox(f(0.0), log(2.0); atol = 1e-10)
     @test f(-10.0) > 0
-    @test f(10.0) > 0
-    @test isapprox(f(100.0), 100.0; atol=1e-6)
+    @test isapprox(f(100.0), 100.0; atol = 1e-6)
+    @test Coconots.get_link_function("log") === exp
+    @test Coconots.get_link_function("relu")(-1.0) == 1e-10
+    @test Coconots.get_link_function("identity")(2.5) == 2.5
     @test_throws ErrorException Coconots.get_link_function("unknown")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,17 @@ using Test
 using Random
 using ForwardDiff
 using Statistics: mean
+using Aqua
+using JET
+
+@testset "Aqua" begin
+    Aqua.test_all(Coconots; ambiguities = false)
+    Aqua.test_ambiguities(Coconots)
+end
+
+@testset "JET" begin
+    JET.test_package(Coconots; target_defined_modules = true)
+end
 
 @testset "convolution distributions (order 1)" begin
     y = 10


### PR DESCRIPTION
## Summary

Full performance/architecture rework of the computational backend. Results are numerically equivalent to v0.1.x (fitted parameters, log-likelihoods, SEs, scores, PIT and predictive distributions agree to ≤ 3e-9 relative), while every hot path gets substantially faster. The R-bridge contract (positional `cocoReg` arguments, all return-dict keys) is unchanged.

> Includes the `fix/cocoboot-envelope-quantiles` commit (d424de4); this branch was cut from it.

## Performance (same data, warm timings, single thread)

| Path | Before | After | Speedup |
|---|---|---|---|
| `compute_scores` GP2 / PAR2 | 14.1 s / 8.4 s | 1.2 ms / 1.3 ms | ~11,500× / ~6,500× |
| `cocoReg` GP2 / PAR2 | 200 ms / 125 ms | 22 ms / 8.4 ms | 9–15× |
| `cocoReg` PAR1 / GP1 / GP1+xreg | — | — | 6× / 4× / 2× |
| `cocoPit` (order 2) | 18 ms | 0.14 ms | up to 128× |
| One-step forecast (order 2) | — | — | 22–37× |
| `cocoSim` / `cocoBoot` (order 2) | — | — | 6–9× |

## Core math

- **`GP2Kernel{T}`**: precomputed GP-pmf lookup tables per parameter value; bivariate normalizer and `U`/`beta`/`zeta` invariants hoisted out of all `r`-loops; the `s,v,w` triple sum runs only over the feasible set.
- **No more `BigInt`**: `Float64` factorial table (≤ 170) + log-space evaluation beyond.
- **Unique-transition likelihoods**: constant-rate NLLs aggregate over unique `(x, y[, z])` transitions with multiplicities, precomputed outside the optimizer loop.
- **Single-pass assessment**: scores/PIT/forecasts derive everything from one pmf-vector pass (previously quadratic in `max_x`).
- **Type-stable & generic over `Real`**: no `Union{Float64, Dual}` buffers; order-1 transition probability is allocation-free; serial accumulation fallback when single-threaded.

## Optimization

- **Optimization.jl front end** with pluggable AD (`adtype` kwarg; `AutoForwardDiff()` default, `AutoEnzyme()` verified to reproduce ForwardDiff results exactly) and pluggable solvers; extra kwargs forwarded to `solve`.
- **Transformation-based constraints by default**: logistic / shifted-`exp` transforms, solved unconstrained with `LBFGS()`; `box_constrained = true` restores `Fminbox(LBFGS())`.
- **ForwardDiff compat loosened to `"0.10, 1"`** — fixes `installJuliaPackages()` failures in environments that already hold a ForwardDiff 1.x consumer.

## Bug fixes

- `cocoForwardSim` seeded the previous observations at the end of the state vector where the simulation loop immediately overwrote them — **k ≥ 2 forecasts were conditioned on zeros** instead of the last observations. Now seeded correctly (regression test added); multi-step forecasts now match the RCPP backend's conditioning.
- GP2 starting-value shrink loop wrote `alpha1 = alpha2 * 0.8` (twin of the R-side typo fixed earlier).
- Negative-variance clamp used `10^-12` (Int pow → `DomainError` if reached) instead of `1e-12`.
- `cocoPit` no longer mutates `fit["data"]` in place.
- Kernel entry points validate table sizes instead of relying on `@inbounds`.

## Housekeeping

- Lean `PrecompileTools` workload re-enabled (package precompiles in ~9 s; cuts first-call latency from R).
- SciML-style `.JuliaFormatter.toml`; tree is format-clean.
- Expanded test suite (77 tests) incl. Dual differentiability, fast-path vs direct NLL equivalence, bound-transform round trips, forecast conditioning; `test/Project.toml` added.
- `julia ≥ 1.10`; version bumped to **0.2.0**.

## Verification

- Julia: `Pkg.test()` — 77/77 pass.
- Equivalence harness vs v0.1.2 on PAR1/GP1/PAR2/GP2/GP1+xreg: all quantities ≤ 3e-9 relative.
- R package: full `testthat` suite (`NOT_CRAN=true`, dev-`JULIA_PROJECT`) — **29 pass, 0 fail**, plus an end-to-end bridge script confirming RCPP-vs-Julia agreement on fits, scores, PIT, bootstrap and k-step forecasts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)