### PR TITLE
Add coverage, Aqua, and status badges to README

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,3 +38,9 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # Coconots
 
-[![Build Status](https://github.com/manuhuth/Coconots.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/manuhuth/Coconots.jl/actions/workflows/CI.yml?query=branch%3Amain)
+<a href="https://github.com/manuhuth/Coconots.jl/actions/workflows/CI.yml?query=branch%3Amain">
+    <img src="https://github.com/manuhuth/Coconots.jl/actions/workflows/CI.yml/badge.svg?branch=main" alt="CI"/>
+</a>
+<a href="https://codecov.io/gh/manuhuth/Coconots.jl">
+    <img src="https://codecov.io/gh/manuhuth/Coconots.jl/branch/main/graph/badge.svg" alt="Coverage"/>
+</a>
+<a href="https://github.com/JuliaTesting/Aqua.jl">
+    <img src="https://juliatesting.github.io/Aqua.jl/dev/assets/badge.svg" alt="Aqua QA"/>
+</a>
+<a href="https://julialang.org">
+    <img src="https://img.shields.io/badge/Julia-1.10%2B-9558B2.svg?logo=julia&logoColor=white" alt="Julia 1.10+"/>
+</a>
+<a href="LICENSE">
+    <img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"/>
+</a>
+<a href="https://www.repostatus.org/#active">
+    <img src="https://www.repostatus.org/badges/latest/active.svg" alt="Project Status: Active"/>
+</a>
 
 The `Coconots` package provides a robust and user-friendly Julia framework for analyzing time series consisting of low counts. Likelihood-based methods for model fitting, assessment and prediction analysis of some convolution-closed count time series model are provided. The marginal distribution can be Poisson or Generalized Poisson. Regression effects can be modelled via time varying innovation rates. 
 


### PR DESCRIPTION
## Summary
- Expand the README badge row to match the set used in NoLimits.jl: CI, Codecov coverage, Aqua QA, Julia 1.10+, MIT license, and repo status.
- Add coverage processing + Codecov upload to the CI workflow so the coverage badge is actually populated.

## Notes
- The Aqua badge reflects the existing `Aqua.test_all` run in `test/runtests.jl`.
- Julia badge floor (1.10+) matches the `julia = "1.10"` compat bound.
- Coverage upload requires a `CODECOV_TOKEN` repo secret; `fail_ci_if_error: false` keeps CI green until it's configured.
- Docs badge intentionally omitted — no docs site is deployed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)